### PR TITLE
Use npm OIDC trusted publishing and signed commits in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,6 @@ jobs:
         with:
           version: pnpm ci:version
           publish: pnpm ci:publish
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_VERCEL_TOKEN_ELEVATED }}


### PR DESCRIPTION
## Summary

Two fixes to the release workflow:

1. **Switch to npm OIDC trusted publishing.** Removed `NODE_AUTH_TOKEN: ${{ secrets.NPM_VERCEL_TOKEN_ELEVATED }}`. The job already has `id-token: write` and uses `registry-url: https://registry.npmjs.org` on Node 24 (npm 11.12, well past the 11.5.1 minimum), so npm will now exchange the GitHub Actions OIDC token for a short-lived publish token. While the token env var was set, the changesets action was writing an `.npmrc` that authenticated with the long-lived token, short-circuiting the OIDC flow.

2. **Use `commitMode: github-api` in the changesets action.** The [last release run](https://github.com/vercel-labs/quickjs-wasi/actions/runs/26255850017/job/77278213219) failed with:

   ```
   remote: error: GH013: Repository rule violations found for refs/heads/changeset-release/main.
   remote: - Commits must have verified signatures.
   remote:   Found 1 violation:
   remote:   a5d78ccae43c3f6fa5aa769fe9e903b7b3605961
    ! [remote rejected] HEAD -> changeset-release/main (push declined due to repository rule violations)
   ```

   The default `commitMode: git-cli` produces unsigned commits, which the vercel-labs org's signed-commits rule rejects. `commitMode: github-api` routes commits and tags through the GitHub API, so they're signed with GitHub's GPG key and show up as Verified.

## Required follow-up on npmjs.com

For OIDC to work, the package must have a trusted publisher configured. On the [quickjs-wasi package settings](https://www.npmjs.com/package/quickjs-wasi/access), under **Trusted Publisher**, add a GitHub Actions publisher:

- **Organization or user:** `vercel-labs`
- **Repository:** `quickjs-wasi`
- **Workflow filename:** `release.yml`
- **Environment name:** (leave blank)
- **Allowed actions:** `npm publish`

After the first successful OIDC publish, recommend setting publishing access to **"Require two-factor authentication and disallow tokens"** and revoking `NPM_VERCEL_TOKEN_ELEVATED` if it's unused elsewhere.

Public-repo + public-package + OIDC means provenance attestations will be generated automatically — no extra config needed.
