### PR TITLE
Defer submodule + wasi-sdk init until publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,14 @@ jobs:
       id-token: write
 
     steps:
+      # NOTE: submodules are intentionally not checked out here. The
+      # changesets/action (commitMode: github-api) walks the working tree to
+      # build the commit and fails on the executable files inside the
+      # quickjs-ng submodule. Submodules + wasi-sdk are initialized inside
+      # `ci:publish` instead, which only runs after the version commit/push.
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -38,9 +42,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Setup wasi-sdk
-        run: make setup
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bench:emscripten": "bun run bench/emscripten-benchmark.ts",
     "changeset": "changeset",
     "ci:version": "changeset version && node -e \"fs.writeFileSync('src/version.ts', '// Auto-synced with package.json version. Do not edit manually.\\nexport const VERSION = ' + JSON.stringify(require('./package.json').version) + ';\\n')\"",
-    "ci:publish": "pnpm run build && changeset publish"
+    "ci:publish": "git submodule update --init --recursive && make setup && pnpm run build && changeset publish"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary

Fixes the next release run failure: https://github.com/vercel-labs/quickjs-wasi/actions/runs/26354987710/job/77579992697

```
Error: Unexpected executable file at quickjs-ng/unicode_download.sh, GitHub API only supports non-executable files and directories.
```

## Root cause

`commitMode: github-api` (from #11) makes `changesets/action` use [`@changesets/ghcommit`](https://github.com/changesets/ghcommit), which constructs commits by walking the working tree and uploading file blobs via the GitHub GraphQL API. The GitHub API only accepts blob modes `100644` (regular file) and `040000` (tree) — it does not accept `100755` (executable), symlinks, or gitlinks. This is called out as a known limitation in the [`@changesets/ghcommit` README](https://github.com/changesets/ghcommit#known-limitations):

> - Executable files
> - Symbolic Links
> - Submodule changes

With `submodules: recursive` on checkout, the `quickjs-ng/` directory is populated as a regular directory in the working tree. The walker descends into it, finds `unicode_download.sh` (a `100755` executable), and aborts.

## Fix

Defer submodule initialization until the publish step, so the working tree contains no submodule contents when the changesets action builds its commit:

- Drop `submodules: recursive` from `actions/checkout` in `release.yml`.
- Drop the standalone `make setup` step from the workflow.
- Move `git submodule update --init --recursive && make setup` into the `ci:publish` script, ahead of `pnpm run build`.

The `ci:version` step (run during the "create release PR" phase) doesn't need the submodule or wasi-sdk — it only edits `.changeset/*`, `CHANGELOG.md`, `package.json`, and `src/version.ts`. The submodule and wasi-sdk are only needed by `make` / `build:wasm`, which only runs inside `ci:publish` after the changesets action has already pushed its version commit via the API.
