### PR TITLE
Fix value corruption for singleton primitives in hostToHandle

### DIFF
--- a/.changeset/fix-singleton-dispose.md
+++ b/.changeset/fix-singleton-dispose.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': patch
+---
+
+Fix value corruption when transferring objects/arrays containing `false`, `true`, `null`, or `undefined` into the VM via `hostToHandle`. These primitives resolve to cached singleton handles, and the object/array conversion disposed each value handle after `setProp`, freeing the singleton's shared heap `JSValue` and corrupting later reads (e.g. `false` showing up as `NaN`). Disposing a cached singleton handle is now a no-op.

--- a/src/index.ts
+++ b/src/index.ts
@@ -540,7 +540,7 @@ export class QuickJS {
   /** The global object. Cached — do not dispose. */
   get global(): JSValueHandle {
     if (!this._global) {
-      this._global = new JSValueHandle(this, this.exports.qjs_get_global());
+      this._global = new JSValueHandle(this, this.exports.qjs_get_global(), true);
     }
     return this._global;
   }
@@ -548,7 +548,7 @@ export class QuickJS {
   /** The undefined value. Cached — do not dispose. */
   get undefined(): JSValueHandle {
     if (!this._undefined) {
-      this._undefined = new JSValueHandle(this, this.exports.qjs_get_undefined());
+      this._undefined = new JSValueHandle(this, this.exports.qjs_get_undefined(), true);
     }
     return this._undefined;
   }
@@ -556,7 +556,7 @@ export class QuickJS {
   /** The null value. Cached — do not dispose. */
   get null(): JSValueHandle {
     if (!this._null) {
-      this._null = new JSValueHandle(this, this.exports.qjs_get_null());
+      this._null = new JSValueHandle(this, this.exports.qjs_get_null(), true);
     }
     return this._null;
   }
@@ -564,7 +564,7 @@ export class QuickJS {
   /** The true value. Cached — do not dispose. */
   get true(): JSValueHandle {
     if (!this._true) {
-      this._true = new JSValueHandle(this, this.exports.qjs_get_true());
+      this._true = new JSValueHandle(this, this.exports.qjs_get_true(), true);
     }
     return this._true;
   }
@@ -572,7 +572,7 @@ export class QuickJS {
   /** The false value. Cached — do not dispose. */
   get false(): JSValueHandle {
     if (!this._false) {
-      this._false = new JSValueHandle(this, this.exports.qjs_get_false());
+      this._false = new JSValueHandle(this, this.exports.qjs_get_false(), true);
     }
     return this._false;
   }
@@ -2092,10 +2092,20 @@ export class JSValueHandle {
   /** @internal */
   readonly ptr: number;
   private disposed = false;
+  /**
+   * When true, this handle is a cached singleton (e.g. `undefined`, `null`,
+   * `true`, `false`, the global object) and `dispose()` is a no-op. This
+   * prevents code that routinely disposes handles (such as the object/array
+   * branches of `hostToHandle`) from freeing the shared heap `JSValue*` that
+   * the cached singleton still references, which would corrupt later reads.
+   * @internal
+   */
+  private readonly singleton: boolean;
 
-  constructor(vm: QuickJS, ptr: number) {
+  constructor(vm: QuickJS, ptr: number, singleton = false) {
     this.vm = vm;
     this.ptr = ptr;
+    this.singleton = singleton;
   }
 
   get isUndefined(): boolean {
@@ -2444,6 +2454,11 @@ export class JSValueHandle {
    * Safe to call after the VM has been disposed (becomes a no-op).
    */
   dispose(): void {
+    // Cached singleton handles (undefined/null/true/false/global) share a
+    // single heap-allocated JSValue that the VM keeps referencing. Freeing it
+    // here would leave the cached handle pointing at freed memory, so disposing
+    // a singleton is intentionally a no-op.
+    if (this.singleton) return;
     if (!this.disposed) {
       this.disposed = true;
       // If the VM is already disposed, the WASM instance is gone —

--- a/test/values.test.ts
+++ b/test/values.test.ts
@@ -332,4 +332,48 @@ describe('hostToHandle', () => {
     expect(vm.evalCode('e.name').consume(h => h.toString())).toBe('TypeError');
     expect(vm.evalCode('e.message').consume(h => h.toString())).toBe('boom');
   });
+
+  // Regression test for https://github.com/vercel-labs/quickjs-wasi/issues/14
+  // Singleton primitive values (false/true/null/undefined) used as object or
+  // array members must not be corrupted. The object/array branches dispose
+  // each value handle after setProp; disposing a cached singleton handle used
+  // to free its shared heap JSValue and corrupt subsequent reads.
+  it('should not corrupt singleton primitives nested in objects', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    const value = {
+      pinned: false,
+      tts: true,
+      nonce: null,
+      member: {
+        deaf: false,
+        pending: false,
+        nick: null,
+        flags: 0,
+      },
+      mentions: [false, true, null, undefined],
+    };
+    const result = vm.hostToHandle(value).consume(h => vm.dump(h));
+    expect(result).toEqual({
+      pinned: false,
+      tts: true,
+      nonce: null,
+      member: {
+        deaf: false,
+        pending: false,
+        nick: null,
+        flags: 0,
+      },
+      mentions: [false, true, null, undefined],
+    });
+  });
+
+  it('should keep cached singleton handles usable after object conversion', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    // Converting an object containing `false` previously disposed vm.false.
+    vm.hostToHandle({ a: false, b: null, c: true }).dispose();
+    // The cached singletons must still resolve correctly afterwards.
+    expect(vm.dump(vm.false)).toBe(false);
+    expect(vm.dump(vm.true)).toBe(true);
+    expect(vm.dump(vm.null)).toBe(null);
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes #14: transferring deeply nested objects/arrays into the VM via `hostToHandle` could corrupt primitive values such as `false`, `true`, `null`, and `undefined` (e.g. `pinned: false` reading back inside the VM as the number `NaN`).
- Root cause: those primitives resolve to **cached singleton handles** (`vm.false`, `vm.true`, `vm.null`, `vm.undefined`). The object/array conversion branches in `hostToHandle` dispose each value handle after `setProp`. `dispose()` calls `qjs_free_value`, which `free()`s the shared heap `JSValue*` that the cached singleton still references — so the next use of that singleton reads freed/reused memory.
- Fix: cached singleton handles (`undefined`/`null`/`true`/`false`/`global`) are now flagged, and `JSValueHandle.dispose()` is a no-op for them. This enforces the already-documented "Cached — do not dispose" contract everywhere, not just inside `hostToHandle`.

Note: the standalone `getNull()`/`getTrue()`/`getFalse()`/`getUndefined()` helpers each allocate a fresh heap `JSValue*`, so they remain independently owned and disposable — they are intentionally **not** marked as singletons.

## Testing
- Added two regression tests in `test/values.test.ts`:
  - nested object/array with `false`/`true`/`null`/`undefined` round-trips without corruption.
  - cached singleton handles (`vm.false`/`vm.true`/`vm.null`) stay usable after converting an object that contains them.
- Verified both new tests fail on `main` (reproducing the bug) and pass with the fix.
- Full suite green: `1785 passed`. `tsc --noEmit` clean.

This is a pure TypeScript change; no WASM rebuild required.