### PR TITLE
Resolve remaining js-yaml DoS advisory

### DIFF
--- a/.changeset/fix-js-yaml-vuln.md
+++ b/.changeset/fix-js-yaml-vuln.md
@@ -1,9 +1,8 @@
 ---
-"quickjs-wasi": patch
 ---
 
 Resolve the remaining Dependabot advisory (js-yaml quadratic-complexity DoS,
 GHSA-h67p-54hq-rp68) by overriding the transitive `read-yaml-file` dependency
 to `^2.1.0`, which uses the patched `js-yaml@4` while keeping the same CJS API
 that `@manypkg/get-packages` (a `@changesets/cli` dependency) relies on. This is
-a dev-only tooling dependency and is not part of the published package.
+a repo-only tooling change and does not affect the published package.

--- a/.changeset/fix-js-yaml-vuln.md
+++ b/.changeset/fix-js-yaml-vuln.md
@@ -1,0 +1,9 @@
+---
+"quickjs-wasi": patch
+---
+
+Resolve the remaining Dependabot advisory (js-yaml quadratic-complexity DoS,
+GHSA-h67p-54hq-rp68) by overriding the transitive `read-yaml-file` dependency
+to `^2.1.0`, which uses the patched `js-yaml@4` while keeping the same CJS API
+that `@manypkg/get-packages` (a `@changesets/cli` dependency) relies on. This is
+a dev-only tooling dependency and is not part of the published package.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   dompurify: '>=3.4.11'
   postcss: '>=8.5.10'
   esbuild@>=0.27.3 <0.28.1: '>=0.28.1'
+  read-yaml-file: ^2.1.0
 
 importers:
 
@@ -1543,9 +1544,6 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2296,10 +2294,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
@@ -2747,10 +2741,6 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
-
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -2832,9 +2822,9 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
-  read-yaml-file@1.1.0:
-    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
-    engines: {node: '>=6'}
+  read-yaml-file@2.1.0:
+    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
+    engines: {node: '>=10.13'}
 
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
@@ -2975,9 +2965,6 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -3021,6 +3008,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
 
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
@@ -4175,7 +4166,7 @@ snapshots:
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
-      read-yaml-file: 1.1.0
+      read-yaml-file: 2.1.0
 
   '@mapbox/node-pre-gyp@2.0.3':
     dependencies:
@@ -4665,10 +4656,6 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
     optional: true
-
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -5410,11 +5397,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
@@ -5791,8 +5773,6 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pify@4.0.1: {}
-
   pkce-challenge@5.0.1: {}
 
   pkg-up@3.1.0:
@@ -5871,12 +5851,10 @@ snapshots:
 
   react@19.2.7: {}
 
-  read-yaml-file@1.1.0:
+  read-yaml-file@2.1.0:
     dependencies:
-      graceful-fs: 4.2.11
-      js-yaml: 3.14.2
-      pify: 4.0.1
-      strip-bom: 3.0.0
+      js-yaml: 4.2.0
+      strip-bom: 4.0.0
 
   recast@0.23.11:
     dependencies:
@@ -6118,8 +6096,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  sprintf-js@1.0.3: {}
-
   stackback@0.0.2: {}
 
   state-local@1.0.7: {}
@@ -6161,6 +6137,8 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
+
+  strip-bom@4.0.0: {}
 
   strip-final-newline@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,9 @@ overrides:
   dompurify: ">=3.4.11"
   postcss: ">=8.5.10"
   "esbuild@>=0.27.3 <0.28.1": ">=0.28.1"
+  # @changesets/cli -> @manypkg/get-packages@1 -> read-yaml-file@1 -> js-yaml@3,
+  # which is vulnerable with no patched 3.x release. read-yaml-file@2.1.0 keeps
+  # the same CJS API (incl. .sync) but uses js-yaml@4, so it's a drop-in fix that
+  # doesn't break changesets (bumping @manypkg/get-packages to 2.x changes its API
+  # and breaks the changesets CLI).
+  "read-yaml-file": "^2.1.0"


### PR DESCRIPTION
## Summary

Fixes the one remaining Dependabot alert after #19: **js-yaml quadratic-complexity DoS in merge key handling** ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68), medium, dev-only).

### Root cause

The vulnerable `js-yaml@3.14.2` was pulled in through the changesets tooling:

```
@changesets/cli@2.31.0
└─ @manypkg/get-packages@1.1.3   (changesets pins ^1.1.3 — latest is 3.x)
   └─ read-yaml-file@1.1.0
      └─ js-yaml@3.6.1+           ← vulnerable, fix is 4.2.0
```

The advisory's fix is `js-yaml@4.2.0`, but there's **no patched 3.x release**, and `read-yaml-file@1.1.0` calls `js-yaml`'s `safeLoad()`, which was **removed in js-yaml 4.x** — so js-yaml can't simply be overridden to 4.x.

### Why not bump `@manypkg/get-packages`?

`@manypkg/get-packages@2.x`/`3.x` drop `read-yaml-file` entirely, but they also **change the package's API** — overriding to 2.x breaks the changesets CLI (`TypeError: Cannot read properties of undefined (reading 'dir')`). Verified locally.

### The fix

Override **`read-yaml-file` to `^2.1.0`**, which:
- uses the patched `js-yaml@^4.0.0` (via `yaml.load()`)
- is still **CJS** and still exports the **`.sync()`** method that `@manypkg/get-packages@1.1.3` calls

So it's a drop-in replacement that removes the vulnerable js-yaml without touching the manypkg API.

After the change:
- `js-yaml` resolves to **only 4.2.0** (vulnerable 3.14.2 gone)
- `read-yaml-file` → 2.1.0, `@manypkg/get-packages` stays at 1.1.3 (API intact)

This is a dev-only tooling dependency and is not part of the published package (which has no JS dependencies).

## Test plan

- [x] `pnpm install` resolves with only `js-yaml@4.2.0`
- [x] `pnpm exec changeset status` works (exercises the package-discovery path that broke with the manypkg-2.x approach)
- [x] `changeset version` gets past package discovery (only fails later on the expected `GITHUB_TOKEN` requirement for the changelog formatter, which CI provides)
- [x] `pnpm test` — all 1785 tests pass
- [x] No regressions in previously-fixed packages (dompurify, postcss, esbuild, next, vite, vitest)