### PR TITLE
Resolve module evaluation promises to the module namespace (exports)

### DIFF
--- a/.changeset/module-loader-errors.md
+++ b/.changeset/module-loader-errors.md
@@ -1,0 +1,14 @@
+---
+"quickjs-wasi": patch
+---
+
+Improve module loader error handling:
+
+- Errors thrown by `moduleLoader.load` / `moduleLoader.normalize` now propagate
+  to the guest with their real message instead of being swallowed and replaced
+  by a generic `could not load module` error.
+- Returning a Promise (an `async` callback) from `load` or `normalize` now
+  throws a clear `TypeError` explaining that the callbacks must be synchronous,
+  instead of coercing the Promise to source text and failing with a confusing
+  `SyntaxError`. For async module sources (e.g. loading over `https://`), see
+  the fetch-and-retry pattern documented in the README's "ES Modules" section.

--- a/.changeset/module-namespace-exports.md
+++ b/.changeset/module-namespace-exports.md
@@ -1,0 +1,23 @@
+---
+"quickjs-wasi": minor
+---
+
+Module evaluation now resolves to the module namespace object (its exports).
+
+Previously, evaluating code with `EvalFlags.TYPE_MODULE` (via `evalCode()` or
+`evalBytecode()`) returned a promise that resolved to `undefined`, making it
+impossible to access a module's exports from the host. The evaluation promise
+is now chained so it resolves to the module's namespace object instead —
+matching quickjs-emscripten's behavior:
+
+```typescript
+using promise = vm.evalCode('export default 42', '<eval>', EvalFlags.TYPE_MODULE);
+vm.executePendingJobs();
+const result = await vm.resolvePromise(promise);
+if ('value' in result) {
+  result.value.getProp('default').consume(h => h.toNumber()); // 42
+}
+```
+
+Rejections (a throw during module evaluation) propagate through the returned
+promise unchanged. Fixes [#22](https://github.com/vercel-labs/quickjs-wasi/issues/22).

--- a/README.md
+++ b/README.md
@@ -131,6 +131,62 @@ using vm = await QuickJS.create(wasmBytes);
 }
 ```
 
+### ES Modules
+
+Evaluate code as an ES module with `EvalFlags.TYPE_MODULE`. Module evaluation
+returns a handle to a Promise that resolves to the module's namespace object
+(its exports):
+
+```typescript
+import { QuickJS, EvalFlags } from 'quickjs-wasi';
+
+using vm = await QuickJS.create(wasmBytes);
+
+using promise = vm.evalCode(
+  'export const x = 42; export default "hi";',
+  '<eval>',
+  EvalFlags.TYPE_MODULE
+);
+vm.executePendingJobs();
+
+const result = await vm.resolvePromise(promise);
+if ('error' in result) {
+  console.error(result.error.consume(h => h.toString()));
+} else {
+  using ns = result.value;
+  ns.getProp('x').consume(h => h.toNumber());        // 42
+  ns.getProp('default').consume(h => h.toString());  // "hi"
+}
+```
+
+`import` statements are resolved through the `moduleLoader` option:
+
+```typescript
+using vm = await QuickJS.create({
+  wasm: wasmBytes,
+  moduleLoader: {
+    // Optional: resolve relative specifiers against the importing module
+    normalize: (baseName, specifier) => specifier,
+    // Return the module source code for a given (normalized) specifier
+    load: (name) => {
+      if (name === 'math.js') return 'export const add = (a, b) => a + b;';
+      throw new Error(`Module not found: ${name}`);
+    },
+  },
+});
+
+using promise = vm.evalCode(
+  `import { add } from 'math.js'; export const sum = add(3, 4);`,
+  '<entry>',
+  EvalFlags.TYPE_MODULE
+);
+vm.executePendingJobs();
+const result = await vm.resolvePromise(promise);
+if ('value' in result) {
+  result.value.consume(ns => ns.getProp('sum').consume(h => h.toNumber())); // 7
+}
+```
+
 ### Error Handling
 
 ```typescript
@@ -659,7 +715,7 @@ Plus the `__stack_pointer` WASM global (a single i32).
 
 - **Snapshot size**: Snapshots capture the entire WASM linear memory (~256 KB baseline, grows with heap). Use `serializeSnapshot()` to get a binary buffer, then apply your own compression (gzip/zstd) — the memory compresses very well due to large zero regions.
 - **Stack size limit**: QuickJS-ng disables `JS_SetMaxStackSize` on WASI, so deep recursion causes a WASM trap (not a catchable exception).
-- **ES Modules**: Only script-mode eval is supported. `import`/`export` and module loaders are not yet wired through.
+- **ES Modules**: Supported via `EvalFlags.TYPE_MODULE` and the `moduleLoader` option (see [ES Modules](#es-modules)). Dynamic `import()` resolves through the same loader.
 - **Extension ABI**: Native WASM extensions use an experimental dynamic linking ABI that is [not yet stabilized](https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md). All extensions must be compiled with the same wasi-sdk version as the main module. See [EXTENSIONS.md](./EXTENSIONS.md) for details.
 
 ### Browser Usage

--- a/README.md
+++ b/README.md
@@ -187,6 +187,57 @@ if ('value' in result) {
 }
 ```
 
+#### Async Module Loading
+
+The `load` and `normalize` callbacks are **synchronous** — the engine calls
+them from inside the WASM call stack, which cannot be suspended to await a
+Promise (returning one throws a `TypeError`). To load module sources
+asynchronously (e.g. over `https://`), use the **fetch-and-retry** pattern:
+throw from `load` on a cache miss, fetch the missing module on the host, and
+re-run the eval. Modules already loaded by the runtime are cached and not
+re-requested, so each attempt makes progress one module deeper into the
+dependency graph:
+
+```typescript
+const cache = new Map<string, string>();
+let missing: string | null = null;
+
+using vm = await QuickJS.create({
+  wasm: wasmBytes,
+  moduleLoader: {
+    load: (name) => {
+      const src = cache.get(name);
+      if (src === undefined) {
+        missing = name;
+        throw new Error(`module not cached: ${name}`);
+      }
+      return src;
+    },
+  },
+});
+
+async function evalModule(code: string, filename: string) {
+  while (true) {
+    missing = null;
+    try {
+      return vm.evalCode(code, filename, EvalFlags.TYPE_MODULE);
+    } catch (err) {
+      if (missing === null) throw err; // a real error, not a cache miss
+      const response = await fetch(new URL(missing, 'https://example.com/'));
+      if (!response.ok) throw new Error(`failed to fetch ${missing}`);
+      cache.set(missing, await response.text());
+    }
+  }
+}
+
+using promise = await evalModule(`import { x } from 'mod.js'; export { x };`, '<entry>');
+vm.executePendingJobs();
+const result = await vm.resolvePromise(promise);
+```
+
+Alternatively, pre-fetch all module sources up front and serve them from the
+cache directly.
+
 ### Error Handling
 
 ```typescript

--- a/c/interface.c
+++ b/c/interface.c
@@ -464,8 +464,77 @@ void qjs_destroy(void) {
 
 /* ---- Evaluation ---- */
 
+/*
+ * JSCFunctionData callback that ignores its arguments and returns
+ * func_data[0]. Used to map the module evaluation promise to the
+ * module namespace object.
+ */
+static JSValue resolve_to_func_data(JSContext *ctx, JSValueConst this_val,
+                                    int argc, JSValueConst *argv,
+                                    int magic, JSValueConst *func_data)
+{
+    (void)this_val;
+    (void)argc;
+    (void)argv;
+    (void)magic;
+    return JS_DupValue(ctx, func_data[0]);
+}
+
+/*
+ * Evaluate a compiled module (a JS_TAG_MODULE value from a COMPILE_ONLY
+ * eval) and return a promise that resolves to the module's namespace
+ * object (its exports) instead of undefined.
+ *
+ * Per spec, module evaluation produces a promise that resolves to
+ * undefined, so we chain it: eval_promise.then(() => namespace).
+ * Rejections (e.g. a throw during module evaluation) propagate through
+ * the chained promise unchanged.
+ *
+ * Consumes func_obj.
+ */
+static JSValue eval_module_to_namespace(JSValue func_obj)
+{
+    JSModuleDef *m = (JSModuleDef *)JS_VALUE_GET_PTR(func_obj);
+
+    JSValue eval_result = JS_EvalFunction(ctx, func_obj); /* consumes func_obj */
+    if (JS_IsException(eval_result))
+        return eval_result;
+
+    JSValue ns = JS_GetModuleNamespace(ctx, m);
+    if (JS_IsException(ns)) {
+        JS_FreeValue(ctx, eval_result);
+        return ns;
+    }
+
+    JSValue then_fn = JS_NewCFunctionData(ctx, resolve_to_func_data, 0, 0, 1, &ns);
+    JS_FreeValue(ctx, ns); /* dup'd into func_data */
+    if (JS_IsException(then_fn)) {
+        JS_FreeValue(ctx, eval_result);
+        return then_fn;
+    }
+
+    JSAtom then_atom = JS_NewAtom(ctx, "then");
+    JSValue result = JS_Invoke(ctx, eval_result, then_atom, 1, &then_fn);
+    JS_FreeAtom(ctx, then_atom);
+    JS_FreeValue(ctx, then_fn);
+    JS_FreeValue(ctx, eval_result);
+    return result;
+}
+
 __attribute__((export_name("qjs_eval")))
 JSValue *qjs_eval(const char *code, size_t len, const char *filename, int eval_flags) {
+    /* For module evaluation (without COMPILE_ONLY), compile first so we
+       can access the JSModuleDef, then evaluate and return a promise that
+       resolves to the module namespace (the module's exports) rather than
+       undefined. */
+    if ((eval_flags & JS_EVAL_TYPE_MASK) == JS_EVAL_TYPE_MODULE &&
+        !(eval_flags & JS_EVAL_FLAG_COMPILE_ONLY)) {
+        JSValue func_obj = JS_Eval(ctx, code, len, filename,
+                                   eval_flags | JS_EVAL_FLAG_COMPILE_ONLY);
+        if (JS_IsException(func_obj))
+            return jsvalue_to_heap(func_obj);
+        return jsvalue_to_heap(eval_module_to_namespace(func_obj));
+    }
     JSValue result = JS_Eval(ctx, code, len, filename, eval_flags);
     return jsvalue_to_heap(result);
 }
@@ -510,12 +579,14 @@ JSValue *qjs_eval_bytecode(const uint8_t *buf, size_t buf_len) {
     if (JS_IsException(obj)) {
         return jsvalue_to_heap(obj);
     }
-    /* For modules, resolve dependencies first */
+    /* For modules, resolve dependencies first, then evaluate and return
+       a promise that resolves to the module namespace (the exports) */
     if (JS_VALUE_GET_TAG(obj) == JS_TAG_MODULE) {
         if (JS_ResolveModule(ctx, obj) < 0) {
             JS_FreeValue(ctx, obj);
             return jsvalue_to_heap(JS_EXCEPTION);
         }
+        return jsvalue_to_heap(eval_module_to_namespace(obj));
     }
     JSValue result = JS_EvalFunction(ctx, obj);
     /* JS_EvalFunction consumes obj, no need to free it */

--- a/c/interface.c
+++ b/c/interface.c
@@ -90,7 +90,10 @@ static char *module_normalizer_trampoline(JSContext *ctx,
     (void)opaque;
     char *result = host_module_normalize(module_base_name, module_name);
     if (!result) {
-        JS_ThrowReferenceError(ctx, "could not normalize module '%s'", module_name);
+        /* The host may have already thrown a more specific error via
+           qjs_throw — only throw the generic error if it did not. */
+        if (!JS_HasException(ctx))
+            JS_ThrowReferenceError(ctx, "could not normalize module '%s'", module_name);
         return NULL;
     }
     /* The host allocated with malloc; QuickJS expects js_malloc'd memory.
@@ -109,7 +112,10 @@ static JSModuleDef *module_loader_trampoline(JSContext *ctx,
     size_t source_len = 0;
     char *source = host_module_load(module_name, &source_len);
     if (!source) {
-        JS_ThrowReferenceError(ctx, "could not load module '%s'", module_name);
+        /* The host may have already thrown a more specific error via
+           qjs_throw — only throw the generic error if it did not. */
+        if (!JS_HasException(ctx))
+            JS_ThrowReferenceError(ctx, "could not load module '%s'", module_name);
         return NULL;
     }
 

--- a/c/interface.c
+++ b/c/interface.c
@@ -502,6 +502,16 @@ static JSValue eval_module_to_namespace(JSValue func_obj)
 {
     JSModuleDef *m = (JSModuleDef *)JS_VALUE_GET_PTR(func_obj);
 
+    /* Resolve module dependencies before evaluation. JS_Eval with
+       COMPILE_ONLY already resolves the graph, and quickjs-ng's
+       js_resolve_module early-returns for already-resolved modules, so
+       this is a no-op for that caller — but it is required for modules
+       deserialized from bytecode and keeps this helper self-contained. */
+    if (JS_ResolveModule(ctx, func_obj) < 0) {
+        JS_FreeValue(ctx, func_obj);
+        return JS_EXCEPTION;
+    }
+
     JSValue eval_result = JS_EvalFunction(ctx, func_obj); /* consumes func_obj */
     if (JS_IsException(eval_result))
         return eval_result;
@@ -520,6 +530,11 @@ static JSValue eval_module_to_namespace(JSValue func_obj)
     }
 
     JSAtom then_atom = JS_NewAtom(ctx, "then");
+    if (then_atom == JS_ATOM_NULL) {
+        JS_FreeValue(ctx, then_fn);
+        JS_FreeValue(ctx, eval_result);
+        return JS_EXCEPTION;
+    }
     JSValue result = JS_Invoke(ctx, eval_result, then_atom, 1, &then_fn);
     JS_FreeAtom(ctx, then_atom);
     JS_FreeValue(ctx, then_fn);
@@ -585,13 +600,9 @@ JSValue *qjs_eval_bytecode(const uint8_t *buf, size_t buf_len) {
     if (JS_IsException(obj)) {
         return jsvalue_to_heap(obj);
     }
-    /* For modules, resolve dependencies first, then evaluate and return
-       a promise that resolves to the module namespace (the exports) */
+    /* For modules, evaluate (resolving dependencies first) and return a
+       promise that resolves to the module namespace (the exports) */
     if (JS_VALUE_GET_TAG(obj) == JS_TAG_MODULE) {
-        if (JS_ResolveModule(ctx, obj) < 0) {
-            JS_FreeValue(ctx, obj);
-            return jsvalue_to_heap(JS_EXCEPTION);
-        }
         return jsvalue_to_heap(eval_module_to_namespace(obj));
     }
     JSValue result = JS_EvalFunction(ctx, obj);

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,8 +218,19 @@ export interface QuickJSOptions {
    * can resolve and load modules.
    *
    * Both callbacks are **synchronous** — they must return their result
-   * immediately. For async module resolution, pre-fetch all module sources
-   * before creating the VM and return them from a `Map` in the `load` callback.
+   * immediately. The engine calls them from inside the WASM call stack,
+   * which cannot be suspended to await a Promise; returning a Promise
+   * throws a `TypeError`.
+   *
+   * For async module sources (e.g. loading over `https://`), either
+   * pre-fetch all module sources before evaluating and serve them from a
+   * cache, or use the fetch-and-retry pattern: throw from `load` on a
+   * cache miss, fetch the missing module on the host, and re-run
+   * `evalCode()` — already-loaded modules are cached by the runtime and
+   * are not re-requested. See the "ES Modules" section of the README.
+   *
+   * Errors thrown by either callback propagate to the guest as the
+   * module resolution error.
    */
   moduleLoader?: {
     /**
@@ -947,6 +958,31 @@ export class QuickJS {
       }
     };
 
+    // Throw a host-side error into the QuickJS context so module loader
+    // failures surface with their real message instead of the generic
+    // "could not load module" error.
+    const throwIntoContext = (err: unknown): void => {
+      const errHandle = vm.newError(err instanceof Error ? err : String(err));
+      vm.exports.qjs_throw(errHandle.ptr);
+      errHandle.dispose();
+    };
+
+    // Guard against async (or otherwise non-string-returning) module loader
+    // callbacks. The WASM boundary is synchronous — a Promise cannot be
+    // awaited here — so fail with a clear error instead of coercing the
+    // Promise to source text.
+    const assertSyncString = (value: unknown, callbackName: string): string => {
+      if (typeof value === 'string') return value;
+      const got = value !== null && typeof value === 'object' && typeof (value as PromiseLike<unknown>).then === 'function'
+        ? 'a Promise'
+        : `type ${typeof value}`;
+      throw new TypeError(
+        `moduleLoader.${callbackName} must synchronously return a string (got ${got}). ` +
+        `Async module loading is not supported — pre-fetch module sources instead ` +
+        `(see the "ES Modules" section of the quickjs-wasi README).`
+      );
+    };
+
     // Module normalizer: resolve a specifier relative to a base name.
     // Returns a malloc'd null-terminated string in WASM memory, or 0 (NULL) on error.
     const hostModuleNormalize = (baseNamePtr: number, namePtr: number): number => {
@@ -958,9 +994,10 @@ export class QuickJS {
       const baseName = vm.readCString(baseNamePtr);
       const specifier = vm.readCString(namePtr);
       try {
-        const normalized = vm.moduleNormalizeHandler(baseName, specifier);
+        const normalized = assertSyncString(vm.moduleNormalizeHandler(baseName, specifier), 'normalize');
         return vm.writeString(normalized).ptr;
-      } catch {
+      } catch (err) {
+        throwIntoContext(err);
         return 0;
       }
     };
@@ -971,11 +1008,12 @@ export class QuickJS {
       if (!vm.moduleLoadHandler) return 0;
       const name = vm.readCString(namePtr);
       try {
-        const source = vm.moduleLoadHandler(name);
+        const source = assertSyncString(vm.moduleLoadHandler(name), 'load');
         const { ptr, len } = vm.writeString(source);
         new Uint32Array(vm.exports.memory.buffer, outLenPtr, 1)[0] = len;
         return ptr;
-      } catch {
+      } catch (err) {
+        throwIntoContext(err);
         return 0;
       }
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,12 @@ export type { ExtensionDescriptor, LoadedExtension, DylinkInfo, WasiImports } fr
 export const EvalFlags = {
   /** Global script mode (default). */
   TYPE_GLOBAL: 0 as const,
-  /** Module mode. */
+  /**
+   * Module mode. `evalCode()` returns a handle to a Promise that resolves
+   * to the module's namespace object (its exports), or rejects if module
+   * evaluation throws. Use together with `executePendingJobs()` and
+   * `resolvePromise()`.
+   */
   TYPE_MODULE: (1 << 0) as 1,
   /** Force strict mode. */
   STRICT: (1 << 3) as 8,
@@ -1081,6 +1086,8 @@ export class QuickJS {
    * @param flags - Optional bitwise OR of `EvalFlags.*` constants.
    *   For example, pass `EvalFlags.ASYNC` to allow top-level `await` — the
    *   returned handle will be a Promise that resolves to the completion value.
+   *   With `EvalFlags.TYPE_MODULE` the returned handle is a Promise that
+   *   resolves to the module's namespace object (its exports).
    */
   evalCode(code: string, filename: string = '<eval>', flags: number = 0): JSValueHandle {
     this.assertNotDisposed();
@@ -1131,6 +1138,10 @@ export class QuickJS {
   /**
    * Execute previously compiled bytecode (from `compile()`).
    * Returns the evaluation result as a handle.
+   *
+   * For module bytecode (compiled with `EvalFlags.TYPE_MODULE`), the
+   * returned handle is a Promise that resolves to the module's namespace
+   * object (its exports).
    *
    * @param bytecode - The bytecode `Uint8Array` from `compile()`.
    */

--- a/test/bytecode.test.ts
+++ b/test/bytecode.test.ts
@@ -82,6 +82,22 @@ describe('vm.compile() / vm.evalBytecode()', () => {
     expect(bytecode.length).toBeGreaterThan(0);
   });
 
+  it('should expose module exports when evaluating module bytecode', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    const bytecode = vm.compile('export const x = 42; export default "hi"', 'mod.js', EvalFlags.TYPE_MODULE);
+    using promise = vm.evalBytecode(bytecode);
+    expect(promise.isPromise).toBe(true);
+    vm.executePendingJobs();
+    const resolved = await vm.resolvePromise(promise);
+    if ('error' in resolved) {
+      resolved.error.dispose();
+      expect.unreachable('module evaluation should not reject');
+    }
+    using ns = resolved.value;
+    expect(ns.getProp('x').consume(h => h.toNumber())).toBe(42);
+    expect(ns.getProp('default').consume(h => h.toString())).toBe('hi');
+  });
+
   it('should produce smaller bytecode with STRIP_SOURCE', async () => {
     using vm = await QuickJS.create(wasmBytes);
     const full = vm.compile('function hello() { return "world"; }');

--- a/test/eval.test.ts
+++ b/test/eval.test.ts
@@ -77,9 +77,67 @@ describe('EvalFlags.TYPE_GLOBAL', () => {
 describe('EvalFlags.TYPE_MODULE', () => {
   it('should evaluate code in module mode', async () => {
     using vm = await QuickJS.create(wasmBytes);
-    // Module eval returns an empty object (the module namespace)
+    // Module eval returns a promise that resolves to the module namespace
     using result = vm.evalCode('export const x = 42;', '<eval>', EvalFlags.TYPE_MODULE);
-    expect(vm.typeof(result)).toBe('object');
+    expect(result.isPromise).toBe(true);
+  });
+
+  it('should resolve to the module namespace with named exports', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using promise = vm.evalCode('export const x = 42; export const y = "hi";', '<eval>', EvalFlags.TYPE_MODULE);
+    vm.executePendingJobs();
+    const resolved = await vm.resolvePromise(promise);
+    if ('error' in resolved) {
+      resolved.error.dispose();
+      expect.unreachable('module evaluation should not reject');
+    }
+    using ns = resolved.value;
+    expect(vm.typeof(ns)).toBe('object');
+    expect(ns.getProp('x').consume(h => h.toNumber())).toBe(42);
+    expect(ns.getProp('y').consume(h => h.toString())).toBe('hi');
+  });
+
+  it('should resolve to the module namespace with a default export', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using promise = vm.evalCode('export default 42', '<eval>', EvalFlags.TYPE_MODULE);
+    vm.executePendingJobs();
+    const resolved = await vm.resolvePromise(promise);
+    if ('error' in resolved) {
+      resolved.error.dispose();
+      expect.unreachable('module evaluation should not reject');
+    }
+    using ns = resolved.value;
+    expect(ns.getProp('default').consume(h => h.toNumber())).toBe(42);
+  });
+
+  it('should resolve to the module namespace for a top-level-await module', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using promise = vm.evalCode(
+      'const v = await Promise.resolve(7); export const x = v;',
+      '<eval>',
+      EvalFlags.TYPE_MODULE,
+    );
+    vm.executePendingJobs();
+    const resolved = await vm.resolvePromise(promise);
+    if ('error' in resolved) {
+      resolved.error.dispose();
+      expect.unreachable('module evaluation should not reject');
+    }
+    using ns = resolved.value;
+    expect(ns.getProp('x').consume(h => h.toNumber())).toBe(7);
+  });
+
+  it('should reject the promise when module evaluation throws', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using promise = vm.evalCode('throw new Error("boom"); export const x = 1;', '<eval>', EvalFlags.TYPE_MODULE);
+    vm.executePendingJobs();
+    const resolved = await vm.resolvePromise(promise);
+    if ('value' in resolved) {
+      resolved.value.dispose();
+      expect.unreachable('module evaluation should reject');
+    }
+    using err = resolved.error;
+    expect(err.toString()).toContain('boom');
   });
 
   it('should scope variables to the module (not globalThis)', async () => {

--- a/test/module-loader.test.ts
+++ b/test/module-loader.test.ts
@@ -87,6 +87,65 @@ describe('moduleLoader', () => {
     expect(vm.evalCode('chain').consume(h => h.toString())).toBe('a+b+c');
   });
 
+  it('should expose entry module exports via the returned promise', async () => {
+    const modules = new Map<string, string>([
+      ['math.js', 'export const add = (a, b) => a + b;'],
+    ]);
+
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      moduleLoader: {
+        load: (name) => {
+          const src = modules.get(name);
+          if (!src) throw new Error(`Module not found: ${name}`);
+          return src;
+        },
+      },
+    });
+
+    using promise = vm.evalCode(`
+      import { add } from 'math.js';
+      export const sum = add(3, 4);
+      export default 'entry';
+    `, '<entry>', EvalFlags.TYPE_MODULE);
+    vm.executePendingJobs();
+
+    const resolved = await vm.resolvePromise(promise);
+    if ('error' in resolved) {
+      resolved.error.dispose();
+      expect.unreachable('module evaluation should not reject');
+    }
+    using ns = resolved.value;
+    expect(ns.getProp('sum').consume(h => h.toNumber())).toBe(7);
+    expect(ns.getProp('default').consume(h => h.toString())).toBe('entry');
+  });
+
+  it('should support dynamic import() from script mode', async () => {
+    const modules = new Map<string, string>([
+      ['math.js', 'export const add = (a, b) => a + b;'],
+    ]);
+
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      moduleLoader: {
+        load: (name) => {
+          const src = modules.get(name);
+          if (!src) throw new Error(`Module not found: ${name}`);
+          return src;
+        },
+      },
+    });
+
+    using promise = vm.evalCode(`import('math.js').then(m => m.add(1, 2))`);
+    vm.executePendingJobs();
+    const resolved = await vm.resolvePromise(promise);
+    if ('error' in resolved) {
+      resolved.error.dispose();
+      expect.unreachable('dynamic import should not reject');
+    }
+    expect(resolved.value.consume(h => h.toNumber())).toBe(3);
+  });
+
   it('should throw on module not found', async () => {
     using vm = await QuickJS.create({
       wasm: wasmBytes,

--- a/test/module-loader.test.ts
+++ b/test/module-loader.test.ts
@@ -239,6 +239,112 @@ describe('moduleLoader', () => {
     expect(vm.evalCode('val').consume(h => h.toNumber())).toBe(42);
   });
 
+  it('should propagate the host error message from load()', async () => {
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      moduleLoader: {
+        load: (name) => {
+          throw new Error(`Module not found: ${name}`);
+        },
+      },
+    });
+
+    expect(() => {
+      vm.evalCode(`import { x } from 'missing.js'`, '<entry>', EvalFlags.TYPE_MODULE).dispose();
+    }).toThrow('Module not found: missing.js');
+  });
+
+  it('should throw a clear error when load() is async', async () => {
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      moduleLoader: {
+        // @ts-expect-error — deliberately wrong: load must be synchronous
+        load: async () => 'export const x = 42;',
+      },
+    });
+
+    expect(() => {
+      vm.evalCode(`import { x } from 'math.js'`, '<entry>', EvalFlags.TYPE_MODULE).dispose();
+    }).toThrow('moduleLoader.load must synchronously return a string (got a Promise)');
+  });
+
+  it('should throw a clear error when normalize() is async', async () => {
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      moduleLoader: {
+        // @ts-expect-error — deliberately wrong: normalize must be synchronous
+        normalize: async (_base: string, specifier: string) => specifier,
+        load: () => 'export const x = 42;',
+      },
+    });
+
+    expect(() => {
+      vm.evalCode(`import { x } from 'math.js'`, '<entry>', EvalFlags.TYPE_MODULE).dispose();
+    }).toThrow('moduleLoader.normalize must synchronously return a string (got a Promise)');
+  });
+
+  it('should support async module sources via fetch-and-retry', async () => {
+    // Simulated remote (e.g. https://) module registry with nested imports
+    const remote = new Map<string, string>([
+      ['a.js', 'import { b } from "b.js"; export const a = "a+" + b;'],
+      ['b.js', 'import { c } from "c.js"; export const b = "b+" + c;'],
+      ['c.js', 'export const c = "c";'],
+    ]);
+    const fetchModule = async (name: string): Promise<string> => {
+      await new Promise((r) => setTimeout(r, 1)); // simulate network latency
+      const src = remote.get(name);
+      if (src === undefined) throw new Error(`404: ${name}`);
+      return src;
+    };
+
+    const cache = new Map<string, string>();
+    let missing: string | null = null;
+
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      moduleLoader: {
+        load: (name) => {
+          const src = cache.get(name);
+          if (src === undefined) {
+            missing = name;
+            throw new Error(`module not cached: ${name}`);
+          }
+          return src;
+        },
+      },
+    });
+
+    // Retry eval until all (transitive) module sources are cached. Each
+    // attempt gets one module deeper into the dependency graph; modules
+    // already loaded by the runtime are not re-requested.
+    const evalModule = async (code: string, filename: string) => {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        missing = null;
+        try {
+          return vm.evalCode(code, filename, EvalFlags.TYPE_MODULE);
+        } catch (err) {
+          if (missing === null) throw err;
+          cache.set(missing, await fetchModule(missing));
+        }
+      }
+      throw new Error('too many retries');
+    };
+
+    using promise = await evalModule(
+      'import { a } from "a.js"; export const chain = a;',
+      '<entry>',
+    );
+    vm.executePendingJobs();
+    const resolved = await vm.resolvePromise(promise);
+    if ('error' in resolved) {
+      const msg = resolved.error.toString();
+      resolved.error.dispose();
+      expect.unreachable(`module evaluation should not reject: ${msg}`);
+    }
+    using ns = resolved.value;
+    expect(ns.getProp('chain').consume(h => h.toString())).toBe('a+b+c');
+  });
+
   it('should work after snapshot restore', async () => {
     const modules = new Map<string, string>([
       ['data.js', 'export const data = [1, 2, 3];'],


### PR DESCRIPTION
Fixes #22

## Problem

Evaluating code with `EvalFlags.TYPE_MODULE` returned a promise that resolved to `undefined` (per-spec module evaluation semantics in quickjs-ng), and `c/interface.c` never called `JS_GetModuleNamespace` — so there was no way for the host to access a module's exports.

## Fix

Mirrors quickjs-emscripten's approach: for module evaluation (in both `qjs_eval` and `qjs_eval_bytecode`), the module is compiled with `JS_EVAL_FLAG_COMPILE_ONLY` to obtain the `JSModuleDef`, evaluated with `JS_EvalFunction`, and the resulting evaluation promise is chained (`evalPromise.then(() => namespace)`) so it resolves to the module's namespace object instead of `undefined`. Rejections (a throw during module evaluation) propagate through unchanged.

```ts
using promise = vm.evalCode('export default 42', '<eval>', EvalFlags.TYPE_MODULE);
vm.executePendingJobs();
const result = await vm.resolvePromise(promise);
if ('value' in result) {
  result.value.getProp('default').consume(h => h.toNumber()); // 42
}
```

## Module loader error handling (second commit)

- Errors thrown by `moduleLoader.load` / `normalize` now propagate to the guest with their real message instead of being replaced by the generic `could not load module` error (the C trampolines only throw the generic error if the host didn't already set an exception).
- An `async` `load`/`normalize` callback now fails with a clear `TypeError` ("must synchronously return a string (got a Promise)") instead of coercing the Promise to `[object Promise]` source text and dying with a confusing `SyntaxError`. The WASM boundary is synchronous, so true async loaders aren't possible without Asyncify/JSPI.
- Documented (and test-verified) the **fetch-and-retry** pattern for async module sources (e.g. `https://`): throw from `load` on a cache miss, fetch on the host, retry the eval — the runtime caches already-loaded modules, so each attempt progresses one module deeper into the dependency graph.

## Changes

- `c/interface.c`: new `eval_module_to_namespace()` helper used by `qjs_eval` and `qjs_eval_bytecode`; loader trampolines respect host-thrown exceptions
- `src/index.ts`: async-loader guard + real error propagation in `hostModuleLoad`/`hostModuleNormalize`; doc updates for `EvalFlags.TYPE_MODULE`, `evalCode()`, `evalBytecode()`, and `moduleLoader`
- `README.md`: new "ES Modules" section (incl. "Async Module Loading"); removed the stale "ES Modules not supported" limitation bullet
- Tests: named/default exports, top-level await, rejection propagation, module bytecode, entry-module exports with a module loader, dynamic `import()`, loader error propagation, async-loader guards, and the fetch-and-retry pattern with nested deps

All 1796 tests pass (11 new).