### PR TITLE
fix: exempt host-callback this/argument handles from scopes and dispose()

### DIFF
--- a/.changeset/borrowed-host-call-handles.md
+++ b/.changeset/borrowed-host-call-handles.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': patch
+---
+
+Host-callback `this`/argument handles are now "borrowed": exempt from `withScope()` tracking and `dispose()` is a no-op. Their pointers are owned by the C trampoline (which frees them after the call returns), so a scope active around guest execution — or an explicit dispose inside a callback — previously double-freed the guest values and corrupted the heap. Callbacks retain arguments past their invocation via `dup()`, which takes an owned reference and behaves normally.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1115,14 +1115,21 @@ export class QuickJS {
       return this.exports.qjs_get_undefined();
     }
 
-    const thisHandle = new JSValueHandle(this, thisPtr);
+    // `thisPtr` and the argv entries are OWNED BY THE C TRAMPOLINE, which
+    // frees them after this call returns. Wrap them as borrowed handles:
+    // dispose() is a no-op and they are exempt from `withScope()`
+    // tracking — a scope active around guest execution (e.g. a host
+    // serializer driving a `forEach` visitor) must not free them at its
+    // boundary, which would double-free the guest values and corrupt the
+    // heap. Callbacks retain arguments past their invocation via `dup()`.
+    const thisHandle = new JSValueHandle(this, thisPtr, false, true);
 
     const args: JSValueHandle[] = [];
     if (argc > 0 && argvPtr !== 0) {
       const view = new DataView(this.exports.memory.buffer);
       for (let i = 0; i < argc; i++) {
         const argPtr = view.getUint32(argvPtr + i * 4, true);
-        args.push(new JSValueHandle(this, argPtr));
+        args.push(new JSValueHandle(this, argPtr, false, true));
       }
     }
 
@@ -1506,6 +1513,12 @@ export class QuickJS {
    *
    * `fn` must be synchronous. Handles created after an `await` are outside
    * the scope, because it closes as soon as `fn` returns.
+   *
+   * Host callbacks are safe to trigger inside a scope: the `this`/argument
+   * handles the trampoline passes to a callback wrap C-owned pointers and
+   * are exempt from scope tracking (see `handleHostCall`), so the scope
+   * frees only handles the host actually owns. Handles a callback CREATES
+   * (including `dup()`s of its arguments) are tracked normally.
    */
   withScope<T>(fn: (scope: HandleScope) => T): T {
     this.assertNotDisposed();
@@ -2363,18 +2376,33 @@ export class JSValueHandle {
   private readonly singleton: boolean;
 
   /**
+   * When true, this handle wraps a `JSValue*` OWNED BY THE C CALLER — the
+   * `this`/argument handles the host-call trampoline passes to a host
+   * callback (`handleHostCall`). The C side frees those values after the
+   * call returns, so `dispose()` is a no-op and the handle is never
+   * registered with an active `withScope()` (either would double-free
+   * the guest value and corrupt the heap). A callback that needs to
+   * retain an argument past its own invocation must `dup()` it — the
+   * duplicate takes a fresh reference and behaves like any owned handle.
+   * @internal
+   */
+  private readonly borrowed: boolean;
+
+  /**
    * Extra cleanup to run when this handle is disposed — used by
    * `newEphemeralFunction()` to unregister its host callback.
    * @internal
    */
   _onDispose: (() => void) | undefined;
 
-  constructor(vm: QuickJS, ptr: number, singleton = false) {
+  constructor(vm: QuickJS, ptr: number, singleton = false, borrowed = false) {
     this.vm = vm;
     this.ptr = ptr;
     this.singleton = singleton;
-    // Singletons are shared and outlive any scope.
-    if (!singleton) vm._activeScope?.add(this);
+    this.borrowed = borrowed;
+    // Singletons are shared and outlive any scope; borrowed handles wrap
+    // C-owned pointers that a scope must never free.
+    if (!singleton && !borrowed) vm._activeScope?.add(this);
   }
 
   /**
@@ -2967,8 +2995,10 @@ export class JSValueHandle {
     // Cached singleton handles (undefined/null/true/false/global) share a
     // single heap-allocated JSValue that the VM keeps referencing. Freeing it
     // here would leave the cached handle pointing at freed memory, so disposing
-    // a singleton is intentionally a no-op.
-    if (this.singleton) return;
+    // a singleton is intentionally a no-op. Borrowed handles (host-callback
+    // `this`/arguments) wrap pointers owned by the C caller, which frees them
+    // itself after the call returns — freeing here would double-free.
+    if (this.singleton || this.borrowed) return;
     if (!this.disposed_) {
       this.disposed_ = true;
       this._onDispose?.();

--- a/test/handle-lifetime.test.ts
+++ b/test/handle-lifetime.test.ts
@@ -86,6 +86,83 @@ describe('unregisterHostCallback', () => {
   });
 });
 
+describe('withScope + host callbacks (borrowed handles)', () => {
+  it('does not free host-callback argument handles at scope exit', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+
+    // Regression: the trampoline's `this`/argument handles wrap pointers
+    // OWNED BY THE C CALLER. Before the `borrowed` flag they registered
+    // with the active scope, and the scope's disposal at exit double-freed
+    // the guest values — observed as WASM memory corruption when a host
+    // serializer drove Map/Set `forEach` visitors inside `withScope`.
+    const seen: number[] = [];
+    using visitor = vm.newEphemeralFunction((value) => {
+      seen.push(value.toNumber());
+      return vm.undefined;
+    });
+    vm.setProp(vm.global, 'visit', visitor);
+
+    using guestMap = vm.evalCode('new Map([["a", 1], ["b", 2], ["c", 3]])');
+
+    vm.withScope(() => {
+      using forEach = vm.evalCode('Map.prototype.forEach');
+      vm.callFunction(forEach, guestMap, visitor).dispose();
+    });
+
+    expect(seen).toEqual([1, 2, 3]);
+
+    // The guest heap must still be intact: the map's values were the
+    // callback's argument pointers, which a buggy scope would have freed.
+    // Re-read the original map through the guest to prove they survived
+    // the scope exit.
+    vm.setProp(vm.global, 'm', guestMap);
+    using sum = vm.evalCode(
+      '(() => { let s = 0; for (const v of m.values()) s += v; return s; })()'
+    );
+    expect(sum.toNumber()).toBe(6);
+  });
+
+  it('explicit dispose() of a borrowed argument handle is a no-op', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+
+    using fn = vm.newEphemeralFunction((value, other) => {
+      // A callback must not be able to free the C caller's values.
+      value.dispose();
+      other.dispose();
+      expect(value.disposed).toBe(false);
+      expect(other.disposed).toBe(false);
+      return vm.undefined;
+    });
+    vm.setProp(vm.global, 'cb', fn);
+    vm.evalCode('cb("shared", { n: 1 })').dispose();
+
+    // Guest strings/objects passed as args must remain readable.
+    using still = vm.evalCode('"shared".length');
+    expect(still.toNumber()).toBe(6);
+  });
+
+  it('dup() of a borrowed argument survives past the callback and the scope', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+
+    let retained: ReturnType<typeof vm.newObject> | undefined;
+    using fn = vm.newEphemeralFunction((value) => {
+      retained = value.dup();
+      return vm.undefined;
+    });
+    vm.setProp(vm.global, 'keep', fn);
+
+    vm.withScope(() => {
+      vm.evalCode('keep({ tag: "kept" })').dispose();
+      // The dup was created inside the scope and IS scope-tracked.
+      expect(retained!.disposed).toBe(false);
+    });
+
+    // The dup is an owned reference — the scope disposed it at exit,
+    // exactly like any handle the callback created.
+    expect(retained!.disposed).toBe(true);
+  });
+});
+
 describe('withScope', () => {
   it('disposes handles created inside the scope', async () => {
     using vm = await QuickJS.create(wasmBytes);


### PR DESCRIPTION
## Problem

`handleHostCall` wraps the trampoline's `thisPtr`/argv entries in ordinary `JSValueHandle`s. Those pointers are **owned by the C caller**, which frees them after the call returns — but the handles still registered with any active `withScope()` (the constructor tracks every non-singleton handle), and `dispose()` on them called `qjs_free_value` like any owned handle.

Consequence: a scope active around guest execution that re-enters the host — e.g. a host-side serializer driving `Map`/`Set`/`Headers` `forEach` visitors — freed the borrowed handles at its boundary, **double-freeing the guest values and corrupting the WASM heap**. Found in vercel/workflow#3263, where wrapping the serde's stringify pass in `withScope` produced `RuntimeError: memory access out of bounds` inside `qjs_free_value`. An explicit `dispose()` inside a callback had the same effect. (`getPromiseThen` already defends against a variant of this by suspending the scope around its capture.)

## Fix

A `borrowed` handle flag, set only by `handleHostCall` for `this`/argument handles:

- never registered with the active scope
- `dispose()` is a no-op (same treatment as singletons, with its own flag + rationale)
- `dup()` of a borrowed argument takes an owned reference and behaves like any other handle — scope-tracked and disposable — which remains the documented way for callbacks to retain arguments past their invocation

`withScope()` docs now state the host-callback safety guarantee.

## Tests

Three regression tests in `handle-lifetime.test.ts`: scope-exit safety around a forEach-driven host visitor (the exact corruption shape from workflow), no-op `dispose()` of callback arguments, and `dup()` retention semantics (the dup IS tracked and swept by the enclosing scope). Full suite: 1890 passed.