### PR TITLE
fix: account allocation sizes against memoryLimit on wasm32-wasi

### DIFF
--- a/.changeset/wasi-malloc-usable-size.md
+++ b/.changeset/wasi-malloc-usable-size.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': patch
+---
+
+`memoryLimit` now actually bounds retained memory: the runtime is created with malloc functions that use wasi-libc's `malloc_usable_size`, replacing quickjs-ng's default usable-size which returns 0 on wasm32-wasi. Previously every allocation was accounted as overhead only, so retained ArrayBuffers/TypedArrays (and all other allocations) grew real memory without bound under any limit — reaching GiB under an 8 MiB `memoryLimit` — and `getMemoryUsage().mallocSize` stayed near zero. Workloads near their configured limit may now throw where they silently over-allocated before; raise `memoryLimit` to match actual usage.

--- a/c/interface.c
+++ b/c/interface.c
@@ -8,6 +8,7 @@
  */
 
 #include "quickjs.h"
+#include <malloc.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -271,11 +272,64 @@ const char *qjs_get_quickjs_version(void) {
 /* All intrinsics enabled (same as JS_NewContext) */
 #define QJS_INTRINSIC_ALL 0xFFFFFFFF
 
+/*
+ * Malloc functions with a WORKING usable-size on wasm32-wasi.
+ *
+ * quickjs-ng's default `js__malloc_usable_size` (cutils.h) has no branch
+ * for WASI and falls through to `return 0;`. The memory accounting adds
+ * `usable_size(ptr) + MALLOC_OVERHEAD` per allocation, so with a zero
+ * usable-size every allocation is recorded as overhead only — the actual
+ * bytes never count against `JS_SetMemoryLimit`, and `mallocSize` stays
+ * near zero while real memory grows without bound (retained ArrayBuffers
+ * reach GiB under an 8 MiB limit; see issue #30). The per-allocation
+ * limit check still sees each incoming request's size, which is why one
+ * oversized allocation is refused while many sub-limit ones accumulate
+ * freely.
+ *
+ * wasi-libc's dlmalloc exports `malloc_usable_size`, so wiring it in
+ * makes the accounting — and therefore `memoryLimit` — actually work.
+ */
+static void *qjs_wasi_calloc(void *opaque, size_t count, size_t size) {
+    (void)opaque;
+    return calloc(count, size);
+}
+
+static void *qjs_wasi_malloc(void *opaque, size_t size) {
+    (void)opaque;
+    return malloc(size);
+}
+
+static void qjs_wasi_free(void *opaque, void *ptr) {
+    (void)opaque;
+    free(ptr);
+}
+
+static void *qjs_wasi_realloc(void *opaque, void *ptr, size_t size) {
+    (void)opaque;
+    return realloc(ptr, size);
+}
+
+static size_t qjs_wasi_malloc_usable_size(const void *ptr) {
+    return malloc_usable_size((void *)ptr);
+}
+
+static const JSMallocFunctions qjs_wasi_malloc_funcs = {
+    qjs_wasi_calloc,
+    qjs_wasi_malloc,
+    qjs_wasi_free,
+    qjs_wasi_realloc,
+    qjs_wasi_malloc_usable_size,
+};
+
+static JSRuntime *qjs_new_runtime(void) {
+    return JS_NewRuntime2(&qjs_wasi_malloc_funcs, NULL);
+}
+
 __attribute__((export_name("qjs_init")))
 int qjs_init(void) {
     if (rt) return -1; /* already initialized */
 
-    rt = JS_NewRuntime();
+    rt = qjs_new_runtime();
     if (!rt) return -1;
 
     ctx = JS_NewContext(rt);
@@ -300,7 +354,7 @@ __attribute__((export_name("qjs_init2")))
 int qjs_init2(unsigned int intrinsics) {
     if (rt) return -1; /* already initialized */
 
-    rt = JS_NewRuntime();
+    rt = qjs_new_runtime();
     if (!rt) return -1;
 
     if (intrinsics == QJS_INTRINSIC_ALL) {

--- a/test/limits.test.ts
+++ b/test/limits.test.ts
@@ -25,6 +25,48 @@ describe('memoryLimit', () => {
     expect(msg).not.toBe('ok');
   });
 
+  it('bounds RETAINED ArrayBuffer/TypedArray memory (issue #30)', async () => {
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      memoryLimit: 8 * 1024 * 1024, // 8 MiB
+    });
+
+    // Regression: quickjs-ng's default usable-size returns 0 on
+    // wasm32-wasi, so allocations were recorded as overhead only — the
+    // per-allocation limit check saw each incoming size, but nothing
+    // accumulated in malloc_size. Many sub-limit buffers (each well
+    // under 8 MiB) therefore grew real linear memory without bound:
+    // this exact loop reached ~150 MiB resident under the 8 MiB limit
+    // with no exception. With wasi-libc's malloc_usable_size wired into
+    // the runtime's malloc functions, retention is accounted and the
+    // loop must throw close to the limit.
+    const result = vm.evalCode(`
+      globalThis.keep = [];
+      try {
+        for (var i = 0; i < 300; i++) {
+          var b = new Uint8Array(512 * 1024);
+          b[0] = 1;
+          keep.push(b);
+        }
+        "no-throw";
+      } catch (e) {
+        "threw at " + keep.length;
+      }
+    `);
+    const msg = result.consume((h) => h.toString());
+    expect(msg).not.toBe('no-throw');
+    // 8 MiB limit / 512 KiB buffers ⇒ must stop well before 32 pushes
+    // (heap baseline eats some budget; the pre-fix behavior was 300).
+    const count = Number(msg.replace('threw at ', ''));
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThan(32);
+
+    // The accounting is real: mallocSize reflects the retained bytes.
+    const usage = vm.getMemoryUsage();
+    expect(usage.mallocSize).toBeGreaterThan(4 * 1024 * 1024);
+    expect(usage.mallocSize).toBeLessThanOrEqual(9 * 1024 * 1024);
+  });
+
   it('should allow normal operations within the limit', async () => {
     using vm = await QuickJS.create({
       wasm: wasmBytes,


### PR DESCRIPTION
Fixes #30.

## Root cause

Not ArrayBuffer-specific: quickjs-ng's default `js__malloc_usable_size` (cutils.h) has no branch for WASI and falls through to `return 0;`. The runtime's accounting records `usable_size(ptr) + MALLOC_OVERHEAD` per allocation, so with a zero usable-size **every allocation on this platform was recorded as overhead only**. The per-allocation limit check does see each incoming request's size — which is why a single oversized `ArrayBuffer` was refused — but nothing accumulated in `malloc_size`, so many sub-limit allocations grew real linear memory without bound, and `getMemoryUsage().mallocSize` stayed near zero. ArrayBuffers just make it visible fastest.

## Fix

Create the runtime through `JS_NewRuntime2` with malloc functions whose usable-size is wasi-libc's `malloc_usable_size` (dlmalloc exports it, verified in wasi-sdk 32's sysroot). Contained in our own `c/interface.c` — no submodule patch. Both runtime-creation paths (init + snapshot restore) go through the new factory.

## Verification

The issue's exact repro, before → after (8 MiB `memoryLimit`):

| | before | after |
|---|---|---|
| 300 × 512 KiB retained | all succeed | **throws `InternalError` at ~15** (≈ the limit) |
| `mallocSize` | ~25 KB | 7.95 MiB (accurate) |
| linear memory | 151 MiB | 8.75 MiB |

Full suite (1890 tests) passes against the rebuilt wasm; regression test added asserting both the throw-near-limit behavior and the accurate `mallocSize` accounting.

## On the issue's suggested `WebAssembly.Memory` cap

Deliberately not included here: the module currently *exports* its memory, so accepting a caller-provided memory requires `--import-memory` build/instantiation changes — and with accounting fixed, `memoryLimit` is now a real ceiling on guest allocations, which addresses the DoS vector directly. A hard linear-memory `maximum` is still worthwhile defense-in-depth (stack/code/fragmentation live outside the QuickJS heap) and can be a follow-up.

## Behavior note

Workloads that genuinely use more memory than their configured `memoryLimit` will now throw where they previously over-allocated silently — that's the fix working, but flagging it for release notes (changeset says the same).