### PR TITLE
fix: throw when calling an unregistered host callback

### DIFF
--- a/.changeset/unregistered-callback-throws.md
+++ b/.changeset/unregistered-callback-throws.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': patch
+---
+
+Calling a guest function whose host callback is not registered now throws inside the guest (catchable, or surfaced as a host exception when uncaught), as the `newEphemeralFunction` and `unregisterHostCallback` docs already promised — previously it silently returned `undefined`, masking bugs like un-re-registered callbacks after a snapshot restore.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1112,7 +1112,24 @@ export class QuickJS {
     const name = this.decoder.decode(new Uint8Array(this.exports.memory.buffer, namePtr, nameLen));
     const callback = this.hostCallbacks.get(name);
     if (!callback) {
-      return this.exports.qjs_get_undefined();
+      // Throw inside the guest, as the docs promise: `newEphemeralFunction`
+      // ("calling it after the handle is disposed throws, because the
+      // callback is gone") and `unregisterHostCallback` ("any QuickJS
+      // function still referencing the name will throw when called").
+      // Silently returning `undefined` here masked real bugs — e.g. a
+      // snapshot-restored VM calling a host function that was never
+      // re-registered would corrupt results instead of failing loud.
+      // Guest code can catch this like any other error.
+      const errHandle = this.newError(
+        new Error(
+          `Host callback "${name}" is not registered — it was unregistered, ` +
+            'its ephemeral function handle was disposed, or it was never ' +
+            're-registered after a snapshot restore.'
+        )
+      );
+      this.exports.qjs_throw(errHandle.ptr);
+      errHandle.dispose();
+      return 0;
     }
 
     // `thisPtr` and the argv entries are OWNED BY THE C TRAMPOLINE, which

--- a/src/index.ts
+++ b/src/index.ts
@@ -1120,12 +1120,14 @@ export class QuickJS {
       // snapshot-restored VM calling a host function that was never
       // re-registered would corrupt results instead of failing loud.
       // Guest code can catch this like any other error.
+      // A string (not a host Error object): newError copies an Error's
+      // host .stack into the guest, which would leak host file paths into
+      // guest-observable space and shadow any guest backtrace. This error
+      // is library-generated — there is no host stack worth preserving.
       const errHandle = this.newError(
-        new Error(
-          `Host callback "${name}" is not registered — it was unregistered, ` +
-            'its ephemeral function handle was disposed, or it was never ' +
-            're-registered after a snapshot restore.'
-        )
+        `Host callback "${name}" is not registered — it was unregistered, ` +
+          'its ephemeral function handle was disposed, or it was never ' +
+          're-registered after a snapshot restore.'
       );
       this.exports.qjs_throw(errHandle.ptr);
       errHandle.dispose();

--- a/test/handle-lifetime.test.ts
+++ b/test/handle-lifetime.test.ts
@@ -24,10 +24,28 @@ describe('newEphemeralFunction', () => {
 
     fn.dispose();
 
-    // the guest still holds the function, but the callback is gone: an
-    // unregistered host callback yields `undefined` rather than throwing
-    using after = vm.evalCode('ephemeral()');
-    expect(after.isUndefined).toBe(true);
+    // The guest still holds the function, but the callback is gone: the
+    // call throws inside the guest (as the newEphemeralFunction docs
+    // promise), and the error is catchable like any other guest error.
+    using after = vm.evalCode(
+      'try { ephemeral(); "no-throw" } catch (e) { e.message }'
+    );
+    expect(after.toString()).toContain('is not registered');
+  });
+
+  it('a call after unregisterHostCallback throws inside the guest', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+
+    using fn = vm.newFunction('goner', () => vm.newString('alive'));
+    vm.setProp(vm.global, 'goner', fn);
+    expect(vm.evalCode('goner()').consume((h) => h.toString())).toBe('alive');
+
+    expect(vm.unregisterHostCallback('goner')).toBe(true);
+
+    // Uncaught in the guest: surfaces as a host-side exception.
+    expect(() => vm.evalCode('goner()')).toThrow(
+      '"goner" is not registered'
+    );
   });
 
   it('does not leak callbacks across many calls', async () => {
@@ -67,8 +85,12 @@ describe('unregisterHostCallback', () => {
 
     expect(vm.unregisterHostCallback('greet')).toBe(true);
     expect(vm.unregisterHostCallback('greet')).toBe(false);
-    using after = vm.evalCode('greet()');
-    expect(after.isUndefined).toBe(true);
+    // A call through the still-reachable guest function now throws, as
+    // the unregisterHostCallback docs promise.
+    using after = vm.evalCode(
+      'try { greet(); "no-throw" } catch (e) { e.message }'
+    );
+    expect(after.toString()).toContain('"greet" is not registered');
   });
 
   it('frees the name for reuse', async () => {


### PR DESCRIPTION
Fixes #29.

The reporter is right on both counts: the behavior contradicted the docs, and of the two ways to resolve it, throwing is the correct one — the docs describe the *intended* contract (`newEphemeralFunction`: *"calling it after the handle is disposed throws, because the callback is gone"*; `unregisterHostCallback`: *"any QuickJS function still referencing the name will throw when called"*), and the silent `undefined` actively masks bugs. The sharpest example: a snapshot-restored VM calling a host function that was never re-registered would silently compute with `undefined` instead of failing loud.

## Change

`handleHostCall` now throws an `Error` inside the guest (via `qjs_throw`, mirroring the existing callback-exception path) naming the callback and the likely causes (unregistered / ephemeral handle disposed / not re-registered after restore). Guest code can catch it like any other error; uncaught, it surfaces to the host as an exception.

## Tests

Two existing tests pinned the old silent-`undefined` behavior (contradicting the docs) — updated to assert the throw. New coverage: guest-side catchability for both the disposed-ephemeral and `unregisterHostCallback` paths, and host-side surfacing when uncaught. Full suite: 1891 passed.

## Compat note

Code that deliberately called into unregistered callbacks and relied on `undefined` will now see throws — the changeset flags this. Given both doc sites promised a throw, that reliance was on unspecified behavior.