### PR TITLE
feat: lossless string transport across the WASM boundary

### DIFF
--- a/.changeset/lossless-strings.md
+++ b/.changeset/lossless-strings.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': minor
+---
+
+Lossless string transport across the WASM boundary: `toString()` reads length-aware WTF-8 (embedded U+0000 no longer truncates; lone surrogates survive instead of becoming U+FFFD), host→guest strings (`newString`, `evalCode` sources, property keys) encode WTF-8, and the string-key property APIs (`getProp`/`setProp`/`defineProp`/`hasOwnProperty`/`propertyIsEnumerable`) transparently route keys that C strings cannot express through length-aware guest values. Every JS string — any sequence of UTF-16 code units — now round-trips exactly.

--- a/.changeset/lossless-strings.md
+++ b/.changeset/lossless-strings.md
@@ -2,4 +2,4 @@
 'quickjs-wasi': minor
 ---
 
-Lossless string transport across the WASM boundary: `toString()` reads length-aware WTF-8 (embedded U+0000 no longer truncates; lone surrogates survive instead of becoming U+FFFD), host→guest strings (`newString`, `evalCode` sources, property keys) encode WTF-8, and the string-key property APIs (`getProp`/`setProp`/`defineProp`/`hasOwnProperty`/`propertyIsEnumerable`) transparently route keys that C strings cannot express through length-aware guest values. Every JS string — any sequence of UTF-16 code units — now round-trips exactly.
+Strings now cross the WASM boundary losslessly in both directions — embedded NULs and lone surrogates survive `toString()`, `newString()`, `evalCode()` sources, property keys, and enumeration.

--- a/c/interface.c
+++ b/c/interface.c
@@ -767,6 +767,21 @@ const char *qjs_get_string(JSValue *val) {
     return JS_ToCString(ctx, *val);
 }
 
+/*
+ * Length-aware string conversion. Unlike qjs_get_string (JS_ToCString),
+ * the result is NOT consumed via NUL-terminated reads: the byte length is
+ * written to *plen, so embedded U+0000 code units survive. Lone
+ * surrogates survive too — JS_ToCStringLen2 keeps unmatched surrogate
+ * code points, encoding them as 3-byte sequences (WTF-8). The host
+ * decodes WTF-8 (standard UTF-8 plus surrogate-range sequences) to
+ * recover the exact JS string. Free with qjs_free_cstring.
+ */
+__attribute__((export_name("qjs_get_string_len")))
+const char *qjs_get_string_len(JSValue *val, size_t *plen) {
+    if (!ctx) return NULL;
+    return JS_ToCStringLen2(ctx, plen, *val, false);
+}
+
 __attribute__((export_name("qjs_free_cstring")))
 void qjs_free_cstring(const char *str) {
     JS_FreeCString(ctx, str);
@@ -1318,6 +1333,30 @@ int qjs_has_own_property(JSValue *obj, const char *name) {
 }
 
 /*
+ * qjs_has_own_property with a JSValue key instead of a C string. C-string
+ * keys cannot express embedded NULs or lone surrogates; a JSValue key
+ * (from qjs_new_string, which is length-aware) can — and also supports
+ * symbols.
+ */
+__attribute__((export_name("qjs_has_own_property_value")))
+int qjs_has_own_property_value(JSValue *obj, JSValue *key) {
+    JSAtom atom = JS_ValueToAtom(ctx, *key);
+    if (atom == JS_ATOM_NULL) return -1;
+    JSPropertyDescriptor desc;
+    int ret = JS_GetOwnProperty(ctx, &desc, *obj, atom);
+    JS_FreeAtom(ctx, atom);
+    if (ret > 0) {
+        JS_FreeValue(ctx, desc.value);
+        if (desc.flags & JS_PROP_GETSET) {
+            JS_FreeValue(ctx, desc.getter);
+            JS_FreeValue(ctx, desc.setter);
+        }
+        return 1;
+    }
+    return ret;
+}
+
+/*
  * Check if a property is enumerable.
  * Returns 1 if the property is own and enumerable, 0 otherwise, -1 on error.
  */
@@ -1338,6 +1377,27 @@ int qjs_property_is_enumerable(JSValue *obj, const char *name) {
         return enumerable;
     }
     return ret; /* 0 = not found, -1 = error */
+}
+
+/* qjs_property_is_enumerable with a JSValue key — see
+ * qjs_has_own_property_value for why. */
+__attribute__((export_name("qjs_property_is_enumerable_value")))
+int qjs_property_is_enumerable_value(JSValue *obj, JSValue *key) {
+    JSAtom atom = JS_ValueToAtom(ctx, *key);
+    if (atom == JS_ATOM_NULL) return -1;
+    JSPropertyDescriptor desc;
+    int ret = JS_GetOwnProperty(ctx, &desc, *obj, atom);
+    JS_FreeAtom(ctx, atom);
+    if (ret > 0) {
+        int enumerable = (desc.flags & JS_PROP_ENUMERABLE) ? 1 : 0;
+        JS_FreeValue(ctx, desc.value);
+        if (desc.flags & JS_PROP_GETSET) {
+            JS_FreeValue(ctx, desc.getter);
+            JS_FreeValue(ctx, desc.setter);
+        }
+        return enumerable;
+    }
+    return ret;
 }
 
 /*

--- a/src/index.ts
+++ b/src/index.ts
@@ -415,6 +415,9 @@ interface QuickJSExports {
   // Value management
   qjs_dup_value(valPtr: number): number;
   qjs_free_value(valPtr: number): void;
+  qjs_get_string_len(valPtr: number, plenPtr: number): number;
+  qjs_has_own_property_value(objPtr: number, keyPtr: number): number;
+  qjs_property_is_enumerable_value(objPtr: number, keyPtr: number): number;
 
   // Property operations
   qjs_get_global(): number;
@@ -1169,7 +1172,10 @@ export class QuickJS {
 
   /** Write a JS string into WASM memory, returning the pointer. Caller must free. */
   private writeString(str: string): { ptr: number; len: number } {
-    const encoded = this.encoder.encode(str);
+    // WTF-8 (not plain TextEncoder): lone surrogates in the input must
+    // reach the guest intact — quickjs's decoder accepts the 3-byte
+    // surrogate sequences, so a JS string round-trips exactly.
+    const encoded = encodeWtf8(str);
     const ptr = this.exports.wasm_malloc(encoded.length + 1);
     if (ptr === 0) throw new Error('wasm_malloc failed');
     const mem = new Uint8Array(this.exports.memory.buffer);
@@ -2299,6 +2305,116 @@ export class QuickJS {
   }
 }
 
+// ---- lossless string helpers ----
+
+/**
+ * Whether a string-typed property key survives the NUL-terminated
+ * C-string key APIs: embedded U+0000 truncates the key, and an UNPAIRED
+ * surrogate cannot be UTF-8 encoded (paired surrogates — e.g. emoji —
+ * encode fine). Keys that don't survive are routed through length-aware
+ * guest string values instead.
+ */
+function stringKeyNeedsValuePath(key: string): boolean {
+  return key.includes('\u0000') || LONE_SURROGATE_RE.test(key);
+}
+
+const wtf8Decoder = new TextDecoder();
+const wtf8Encoder = new TextEncoder();
+
+const LONE_SURROGATE_RE =
+  /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF]))|(?:(?<![\uD800-\uDBFF])[\uDC00-\uDFFF])/;
+
+/**
+ * Encode a JS string to WTF-8 bytes. Well-formed strings (including
+ * paired surrogates — emoji) take the native TextEncoder; strings with
+ * LONE surrogates take a manual encode that writes each unpaired
+ * surrogate as the 3-byte sequence quickjs's tolerant UTF-8 decoder
+ * accepts — TextEncoder would replace them with U+FFFD, silently
+ * corrupting every host→guest string (sources, property keys,
+ * newString values).
+ */
+function encodeWtf8(str: string): Uint8Array {
+  if (!LONE_SURROGATE_RE.test(str)) return wtf8Encoder.encode(str);
+  const bytes: number[] = [];
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+    if (code < 0x80) {
+      bytes.push(code);
+    } else if (code < 0x800) {
+      bytes.push(0xc0 | (code >> 6), 0x80 | (code & 0x3f));
+    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < str.length) {
+      const next = str.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        // Well-formed pair — 4-byte UTF-8.
+        const cp = 0x10000 + ((code - 0xd800) << 10) + (next - 0xdc00);
+        bytes.push(
+          0xf0 | (cp >> 18),
+          0x80 | ((cp >> 12) & 0x3f),
+          0x80 | ((cp >> 6) & 0x3f),
+          0x80 | (cp & 0x3f)
+        );
+        i++;
+        continue;
+      }
+      // Lone high surrogate — 3-byte WTF-8.
+      bytes.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
+    } else {
+      // BMP char or lone (low / trailing high) surrogate — 3-byte form.
+      bytes.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
+    }
+  }
+  return new Uint8Array(bytes);
+}
+
+/**
+ * Decode WTF-8 bytes to a JS string. WTF-8 is UTF-8 extended with 3-byte
+ * sequences for surrogate code points (0xED 0xA0-0xBF 0x80-0xBF), which
+ * is how quickjs's JS_ToCStringLen2 encodes lone surrogates ("keep
+ * unmatched surrogate code points"). TextDecoder replaces those
+ * sequences with U+FFFD, so they are detected first and the rare strings
+ * containing them take a manual decode; everything else — the
+ * overwhelming majority — uses the native decoder.
+ */
+function decodeWtf8(bytes: Uint8Array): string {
+  let hasSurrogateSequence = false;
+  for (let i = 0; i < bytes.length - 1; i++) {
+    if (bytes[i] === 0xed && bytes[i + 1] >= 0xa0 && bytes[i + 1] <= 0xbf) {
+      hasSurrogateSequence = true;
+      break;
+    }
+  }
+  if (!hasSurrogateSequence) return wtf8Decoder.decode(bytes);
+
+  let out = '';
+  let i = 0;
+  while (i < bytes.length) {
+    const b0 = bytes[i];
+    if (b0 < 0x80) {
+      out += String.fromCharCode(b0);
+      i += 1;
+    } else if (b0 < 0xe0) {
+      out += String.fromCharCode(((b0 & 0x1f) << 6) | (bytes[i + 1] & 0x3f));
+      i += 2;
+    } else if (b0 < 0xf0) {
+      // 3-byte sequence — may decode into the surrogate range, which is
+      // exactly the WTF-8 extension: emit the code unit as-is.
+      out += String.fromCharCode(
+        ((b0 & 0x0f) << 12) | ((bytes[i + 1] & 0x3f) << 6) | (bytes[i + 2] & 0x3f)
+      );
+      i += 3;
+    } else {
+      const cp =
+        ((b0 & 0x07) << 18) |
+        ((bytes[i + 1] & 0x3f) << 12) |
+        ((bytes[i + 2] & 0x3f) << 6) |
+        (bytes[i + 3] & 0x3f);
+      out += String.fromCodePoint(cp);
+      i += 4;
+    }
+  }
+  return out;
+}
+
 // ---- JSException ----
 
 /**
@@ -2781,6 +2897,12 @@ export class JSValueHandle {
    * Check if a property is an own property (equivalent to Object.prototype.hasOwnProperty).
    */
   hasOwnProperty(name: string): boolean {
+    if (stringKeyNeedsValuePath(name)) {
+      using keyHandle = this.vm.newString(name);
+      return (
+        this.vm._getExports().qjs_has_own_property_value(this.ptr, keyHandle.ptr) === 1
+      );
+    }
     const { ptr: namePtr } = this.vm._writeString(name);
     const result = this.vm._getExports().qjs_has_own_property(this.ptr, namePtr);
     this.vm._getExports().wasm_free(namePtr);
@@ -2791,6 +2913,15 @@ export class JSValueHandle {
    * Check if a property is enumerable (equivalent to Object.prototype.propertyIsEnumerable).
    */
   propertyIsEnumerable(name: string): boolean {
+    if (stringKeyNeedsValuePath(name)) {
+      using keyHandle = this.vm.newString(name);
+      return (
+        this.vm._getExports().qjs_property_is_enumerable_value(
+          this.ptr,
+          keyHandle.ptr
+        ) === 1
+      );
+    }
     const { ptr: namePtr } = this.vm._writeString(name);
     const result = this.vm._getExports().qjs_property_is_enumerable(this.ptr, namePtr);
     this.vm._getExports().wasm_free(namePtr);
@@ -2839,6 +2970,12 @@ export class JSValueHandle {
    * Get a property by name.
    */
   getProp(name: string): JSValueHandle {
+    if (stringKeyNeedsValuePath(name)) {
+      // A NUL or lone surrogate in the key cannot cross the C-string
+      // API; go through a length-aware guest string key instead.
+      using keyHandle = this.vm.newString(name);
+      return this.vm.getProp(this, keyHandle);
+    }
     const { ptr: namePtr } = this.vm._writeString(name);
     const resultPtr = this.vm._getExports().qjs_get_prop_string(this.ptr, namePtr);
     this.vm._getExports().wasm_free(namePtr);
@@ -2849,6 +2986,11 @@ export class JSValueHandle {
    * Set a property by name.
    */
   setProp(name: string, value: JSValueHandle): void {
+    if (stringKeyNeedsValuePath(name)) {
+      using keyHandle = this.vm.newString(name);
+      this.vm.setProp(this, keyHandle, value);
+      return;
+    }
     const { ptr: namePtr } = this.vm._writeString(name);
     this.vm._getExports().qjs_set_prop_string(this.ptr, namePtr, value.ptr);
     this.vm._getExports().wasm_free(namePtr);
@@ -2868,6 +3010,11 @@ export class JSValueHandle {
     if (descriptor?.writable) flags |= 2;     // JS_PROP_WRITABLE
     if (descriptor?.enumerable) flags |= 4;   // JS_PROP_ENUMERABLE
     if (typeof key === 'string') {
+      if (stringKeyNeedsValuePath(key)) {
+        using keyHandle = this.vm.newString(key);
+        this.vm._getExports().qjs_define_prop_value(this.ptr, keyHandle.ptr, value.ptr, flags);
+        return;
+      }
       const { ptr: namePtr } = this.vm._writeString(key);
       this.vm._getExports().qjs_define_prop_string(this.ptr, namePtr, value.ptr, flags);
       this.vm._getExports().wasm_free(namePtr);
@@ -2981,11 +3128,27 @@ export class JSValueHandle {
    * `vm.callFunction`) when a specific conversion is wanted.
    */
   toString(): string {
-    const cstrPtr = this.vm._getExports().qjs_get_string(this.ptr);
-    if (cstrPtr === 0) return '<null>';
-    const str = this.vm._readCString(cstrPtr);
-    this.vm._getExports().qjs_free_cstring(cstrPtr);
-    return str;
+    // Length-aware + WTF-8 (qjs_get_string_len): embedded U+0000 code
+    // units survive (the byte length is explicit, not NUL-scanned) and
+    // lone surrogates survive (quickjs encodes unmatched surrogate code
+    // points as 3-byte WTF-8 sequences, decoded back to their original
+    // code units). The previous JS_ToCString/NUL-terminated read
+    // silently truncated at the first NUL and replaced lone surrogates
+    // with U+FFFD — and the two corruptions could cancel each other's
+    // length changes, defeating length-based detection downstream.
+    const e = this.vm._getExports();
+    const lenPtr = e.wasm_malloc(4);
+    try {
+      const cstrPtr = e.qjs_get_string_len(this.ptr, lenPtr);
+      if (cstrPtr === 0) return '<null>';
+      const len = new DataView(e.memory.buffer).getUint32(lenPtr, true);
+      const bytes = new Uint8Array(e.memory.buffer, cstrPtr, len);
+      const str = decodeWtf8(bytes);
+      e.qjs_free_cstring(cstrPtr);
+      return str;
+    } finally {
+      e.wasm_free(lenPtr);
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -3138,6 +3138,10 @@ export class JSValueHandle {
     // length changes, defeating length-based detection downstream.
     const e = this.vm._getExports();
     const lenPtr = e.wasm_malloc(4);
+    // Same failure check as writeString(): a 0 return would make
+    // qjs_get_string_len write the length to address 0 and the DataView
+    // read below read from it — silent corruption instead of an error.
+    if (lenPtr === 0) throw new Error('wasm_malloc failed');
     try {
       const cstrPtr = e.qjs_get_string_len(this.ptr, lenPtr);
       if (cstrPtr === 0) return '<null>';

--- a/test/lossless-strings.test.ts
+++ b/test/lossless-strings.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { QuickJS } from '../src/index.ts';
+import { wasmBytes } from './helpers.ts';
+
+/**
+ * Lossless string transport across the WASM boundary.
+ *
+ * Guest→host previously read strings through NUL-terminated
+ * `JS_ToCString`: embedded U+0000 truncated the string, and lone
+ * surrogates were replaced with U+FFFD — and the two corruptions can
+ * cancel each other's length changes, so no length check downstream can
+ * detect the loss. Host→guest previously encoded with TextEncoder, which
+ * replaces lone surrogates with U+FFFD before the guest ever sees them
+ * (and can mask the guest→host loss in tests by corrupting both sides
+ * identically).
+ *
+ * Now: guest→host reads length-aware WTF-8 (`qjs_get_string_len`), and
+ * host→guest writes WTF-8 (`writeString`), so every JS string — a
+ * sequence of arbitrary UTF-16 code units — round-trips exactly. Keys are
+ * covered by routing string keys that C strings cannot express (NULs,
+ * unpaired surrogates) through length-aware guest string values.
+ */
+
+// Escape source so the guest receives exact code units regardless of the
+// transport under test (avoids the both-sides-corrupted trap).
+// NOTE: iterate by CODE UNIT (index), not by code point — Array.from /
+// for..of iterate code points and would collapse surrogate pairs.
+const guestLiteral = (s: string) => {
+  let out = '"';
+  for (let i = 0; i < s.length; i++) {
+    out += `\\u${s.charCodeAt(i).toString(16).padStart(4, '0')}`;
+  }
+  return `${out}"`;
+};
+
+const CASES: [string, string][] = [
+  ['embedded NUL', 'ab\u0000cd'],
+  ['leading NUL', '\u0000x'],
+  ['trailing NUL', 'x\u0000'],
+  ['bare lone high surrogate', '\ud800'],
+  ['bare lone low surrogate', '\udfff'],
+  ['length-canceling surrogate + NUL', '\ud800\u0000a'],
+  ['legit replacement char', 'already\ufffdhere'],
+  ['well-formed pair (emoji)', 'emoji \u{1F600} pair'],
+  ['mixed', 'a\u0000\ud800\u{1F600}\udc00z'],
+];
+
+describe('guest→host: toString is lossless', () => {
+  it.each(CASES)('%s', async (_name, value) => {
+    using vm = await QuickJS.create(wasmBytes);
+    using handle = vm.evalCode(guestLiteral(value));
+    expect(handle.toString()).toBe(value);
+    expect(handle.length).toBe(value.length);
+  });
+});
+
+describe('host→guest: newString / evalCode sources are lossless', () => {
+  it.each(CASES)('newString: %s', async (_name, value) => {
+    using vm = await QuickJS.create(wasmBytes);
+    using handle = vm.newString(value);
+    vm.setProp(vm.global, 'probe', handle);
+    using match = vm.evalCode(`probe === ${guestLiteral(value)}`);
+    expect(match.toBoolean()).toBe(true);
+  });
+
+  it('full host→guest→host round trip', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    for (const [, value] of CASES) {
+      using handle = vm.newString(value);
+      expect(handle.toString()).toBe(value);
+    }
+  });
+});
+
+describe('property keys with NULs / lone surrogates', () => {
+  const KEY_OBJ = `({
+    ${guestLiteral('a\u0000b')}: 1,
+    ${guestLiteral('\ud800k')}: 2,
+    ${guestLiteral('mix\ud800\u0000ed')}: 3,
+    plain: 4,
+  })`;
+
+  it('enumeration APIs return exact keys', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using obj = vm.evalCode(KEY_OBJ);
+    expect(obj.keys()).toEqual(['a\u0000b', '\ud800k', 'mix\ud800\u0000ed', 'plain']);
+    expect(obj.getOwnPropertyNames()).toEqual([
+      'a\u0000b',
+      '\ud800k',
+      'mix\ud800\u0000ed',
+      'plain',
+    ]);
+  });
+
+  it('getProp / setProp round-trip mangled keys', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using obj = vm.evalCode(KEY_OBJ);
+    expect(obj.getProp('a\u0000b').consume((h) => h.toNumber())).toBe(1);
+    expect(obj.getProp('\ud800k').consume((h) => h.toNumber())).toBe(2);
+    expect(obj.getProp('mix\ud800\u0000ed').consume((h) => h.toNumber())).toBe(3);
+
+    using value = vm.newNumber(9);
+    obj.setProp('new\u0000\ud800key', value);
+    using read = obj.getProp('new\u0000\ud800key');
+    expect(read.toNumber()).toBe(9);
+  });
+
+  it('hasOwnProperty / propertyIsEnumerable / defineProp handle mangled keys', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using obj = vm.evalCode(KEY_OBJ);
+    expect(obj.hasOwnProperty('a\u0000b')).toBe(true);
+    expect(obj.hasOwnProperty('\ud800k')).toBe(true);
+    expect(obj.hasOwnProperty('a')).toBe(false); // NOT the truncated form
+    expect(obj.propertyIsEnumerable('\ud800k')).toBe(true);
+
+    using target = vm.newObject();
+    using v = vm.newNumber(5);
+    target.defineProp('def\u0000\ud800', v, { enumerable: true });
+    expect(target.getProp('def\u0000\ud800').consume((h) => h.toNumber())).toBe(5);
+    expect(target.keys()).toEqual(['def\u0000\ud800']);
+  });
+
+  it('getOwnPropertyDescriptor resolves mangled string keys', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using obj = vm.evalCode(KEY_OBJ);
+    const desc = obj.getOwnPropertyDescriptor('mix\ud800\u0000ed');
+    expect(desc).toBeDefined();
+    expect(desc?.value?.consume((h) => h.toNumber())).toBe(3);
+    desc?.get?.dispose();
+    desc?.set?.dispose();
+  });
+});


### PR DESCRIPTION
Strings crossing the boundary were lossy in both directions, and the failure modes compose in ways that defeat detection:

- **Guest→host** (`toString`, and through it every enumeration API): NUL-terminated `JS_ToCString` reads truncated at embedded U+0000, and lone surrogates became U+FFFD. The two corruptions can **cancel each other's length changes** (a surrogate's replacement expansion offsetting a NUL's truncation), so no host-side length check reliably detects the loss. Found in vercel/workflow#3263's review, where the host-side serde grew multi-layer detection/escape machinery — whose in-guest `JSON.stringify` escape hatch turned out to be lossy for lone surrogates too (quickjs passes them through raw, and the C-string read of *its* output corrupts them).
- **Host→guest** (`writeString` → `newString`, `evalCode` sources, property keys): TextEncoder replaces lone surrogates with U+FFFD — which also **masks the guest→host loss in tests** by corrupting both directions identically (bit us during development of this very PR).

## Changes

- `toString()` reads length-aware WTF-8 via new `qjs_get_string_len` (`JS_ToCStringLen2`, `cesu8=false` — quickjs *"keeps unmatched surrogate code points"* as 3-byte sequences). Host decodes WTF-8 with a TextDecoder fast path when no surrogate sequence is present. `keys()` / `getOwnPropertyNames()` / `getOwnPropertyKeys()` become lossless for free.
- `writeString()` encodes WTF-8 (TextEncoder fast path for well-formed strings), fixing `newString`, `evalCode` sources, and every other host→guest string.
- String property keys that C strings cannot express (embedded NUL, unpaired surrogate) transparently route through length-aware guest values: `getProp`/`setProp`/`defineProp` reuse the existing by-value paths; `hasOwnProperty`/`propertyIsEnumerable` get new `qjs_has_own_property_value`/`qjs_property_is_enumerable_value` exports. `getOwnPropertyDescriptor` was already by-value and becomes lossless automatically.

## Result

Every JS string — any sequence of UTF-16 code units — round-trips exactly, in both directions, through values, sources, and keys. Downstream, this lets vercel/workflow delete its `guestString`/`escapeString`/NUL-key-routing machinery entirely.

## Tests

23 new (`lossless-strings.test.ts`): both directions × {embedded/leading/trailing NUL, bare lone high/low surrogates, the length-canceling surrogate+NUL shape, legit-U+FFFD passthrough, well-formed pairs, mixed}, plus every string-key API against NUL/surrogate/mixed keys. One test-infra lesson encoded in a comment: building expected values with `Array.from` iterates code *points* and silently collapses pairs — iterate code units. Full suite: 1915 passed.