### PR TITLE
feat: snapshot-portable handles (exportHandle / importHandle)

### DIFF
--- a/.changeset/snapshot-portable-handles.md
+++ b/.changeset/snapshot-portable-handles.md
@@ -2,4 +2,4 @@
 'quickjs-wasi': minor
 ---
 
-`vm.exportHandle(handle)` / `vm.importHandle(token)`: turn a live handle into a snapshot-portable token and re-materialize it — on the same VM or on any VM restored from a snapshot taken while the handle was alive. Enables boot-time capture of pristine intrinsics before user code runs, without re-executing capture code in restored VMs.
+Add `vm.exportHandle()` / `vm.importHandle()` for snapshot-portable handle tokens, enabling pre-snapshot captures to be re-materialized in restored VMs without executing guest code.

--- a/.changeset/snapshot-portable-handles.md
+++ b/.changeset/snapshot-portable-handles.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': minor
+---
+
+`vm.exportHandle(handle)` / `vm.importHandle(token)`: turn a live handle into a snapshot-portable token and re-materialize it — on the same VM or on any VM restored from a snapshot taken while the handle was alive. Enables boot-time capture of pristine intrinsics before user code runs, without re-executing capture code in restored VMs.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1563,6 +1563,59 @@ export class QuickJS {
   }
 
   /**
+   * Export a handle as a snapshot-portable token.
+   *
+   * A handle's heap box lives in the VM's linear memory, so a
+   * `snapshot()` taken while the handle is alive carries it — and a VM
+   * restored from that snapshot has the identical box at the identical
+   * offset. `importHandle(token)` on the restored VM (or on this VM)
+   * re-materializes an owned handle for the same guest value without
+   * evaluating any guest code.
+   *
+   * Contract:
+   * - the handle must stay undisposed until after `snapshot()` — its
+   *   box (and the reference it holds) must be part of the memory image;
+   * - the token is only meaningful to THIS VM and VMs restored from a
+   *   snapshot of it taken while the handle was alive;
+   * - `importHandle` duplicates the underlying value (fresh reference,
+   *   fresh box), so it can be called any number of times and each
+   *   returned handle is independently owned and disposable. The
+   *   exported box's own reference is intentionally never released on
+   *   restored VMs (one retained reference per VM image — reclaimed
+   *   with the VM).
+   *
+   * The intended use is boot-time capture: snapshot a VM after capturing
+   * references to pristine intrinsics but BEFORE evaluating untrusted or
+   * user code, then restore per task and import the captured handles —
+   * guaranteeing the references predate anything user code patched,
+   * without re-running capture code in the restored VM (where user-
+   * patched globals could observe it). See vercel/workflow's host-side
+   * serde for a worked example.
+   */
+  exportHandle(handle: JSValueHandle): number {
+    this.assertNotDisposed();
+    if (handle.vm !== this) {
+      throw new Error('exportHandle: handle belongs to a different VM');
+    }
+    if (handle.disposed) {
+      throw new Error('exportHandle: handle is disposed');
+    }
+    return handle.ptr;
+  }
+
+  /**
+   * Re-materialize a handle from a token produced by `exportHandle` —
+   * on this VM, or on a VM restored from a snapshot taken while the
+   * exported handle was alive. Returns a NEW owned handle (the
+   * underlying value's refcount is incremented); dispose it like any
+   * other handle. See `exportHandle` for the full contract.
+   */
+  importHandle(token: number): JSValueHandle {
+    this.assertNotDisposed();
+    return new JSValueHandle(this, this.exports.qjs_dup_value(token));
+  }
+
+  /**
    * Create a QuickJS function backed by a host callback whose registration is
    * tied to the returned handle: disposing the handle unregisters the
    * callback.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1600,6 +1600,18 @@ export class QuickJS {
     if (handle.disposed) {
       throw new Error('exportHandle: handle is disposed');
     }
+    if (handle._isBorrowed) {
+      // Host-callback this/argument handles wrap boxes OWNED BY THE C
+      // TRAMPOLINE, freed when the callback returns — a token minted
+      // from one would point at freed memory in every restored VM.
+      // Callbacks that need to persist an argument must dup() it first
+      // (the duplicate is an owned box) and export the duplicate.
+      throw new Error(
+        'exportHandle: cannot export a borrowed handle (host-callback ' +
+          'this/argument) — its box is freed when the callback returns. ' +
+          'dup() it and export the duplicate.'
+      );
+    }
     return handle.ptr;
   }
 
@@ -1612,6 +1624,19 @@ export class QuickJS {
    */
   importHandle(token: number): JSValueHandle {
     this.assertNotDisposed();
+    // Best-effort validation before handing the value to qjs_dup_value,
+    // which dereferences it as a raw JSValue* inside the WASM instance.
+    // A malformed token (0, negative, fractional, out of address range)
+    // would otherwise read arbitrary memory. A well-formed but FORGED
+    // token remains undefined behavior — like any raw pointer, tokens
+    // are only meaningful under the exportHandle contract.
+    if (
+      !Number.isInteger(token) ||
+      token <= 0 ||
+      token >= this.exports.memory.buffer.byteLength
+    ) {
+      throw new Error(`importHandle: invalid token ${token}`);
+    }
     return new JSValueHandle(this, this.exports.qjs_dup_value(token));
   }
 
@@ -2475,6 +2500,16 @@ export class JSValueHandle {
     // Singletons are shared and outlive any scope; borrowed handles wrap
     // C-owned pointers that a scope must never free.
     if (!singleton && !borrowed) vm._activeScope?.add(this);
+  }
+
+  /**
+   * Whether this handle wraps a C-owned pointer (host-callback
+   * `this`/arguments). Borrowed handles must never be exported as
+   * snapshot tokens — the trampoline frees their boxes after the
+   * callback returns. @internal
+   */
+  get _isBorrowed(): boolean {
+    return this.borrowed;
   }
 
   /**

--- a/test/portable-handles.test.ts
+++ b/test/portable-handles.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { QuickJS } from '../src/index.ts';
+import { wasmBytes } from './helpers.ts';
+
+/**
+ * Snapshot-portable handles: exportHandle() turns a live handle into a
+ * token that importHandle() re-materializes — on the same VM or on any
+ * VM restored from a snapshot taken while the handle was alive. The
+ * headline use case is boot-time capture of pristine intrinsics before
+ * user code runs (see the exportHandle docs).
+ */
+describe('exportHandle / importHandle', () => {
+  it('re-materializes a captured value in a restored VM without running guest code', async () => {
+    using baseline = await QuickJS.create(wasmBytes);
+
+    // Capture a pristine intrinsic BEFORE "user code" patches it.
+    const pristineToISOString = baseline.evalCode('Date.prototype.toISOString');
+    const token = baseline.exportHandle(pristineToISOString);
+
+    // User code replaces the intrinsic (a polyfill, say).
+    baseline
+      .evalCode('Date.prototype.toISOString = function () { return "patched"; }')
+      .dispose();
+
+    const snapshot = baseline.snapshot();
+    baseline.dispose(); // do NOT dispose the exported handle first
+
+    using restored = await QuickJS.restore(snapshot, wasmBytes);
+    using imported = restored.importHandle(token);
+
+    // The imported handle is the PRISTINE function, not the patch.
+    using date = restored.evalCode('new Date(1700000000000)');
+    using iso = restored.callFunction(imported, date);
+    expect(iso.toString()).toBe('2023-11-14T22:13:20.000Z');
+
+    // The patch is still what guest code observes — the import didn't
+    // mutate the heap, it only referenced a value the heap already held.
+    using patched = restored.evalCode('new Date(0).toISOString()');
+    expect(patched.toString()).toBe('patched');
+  });
+
+  it('imports are independently owned — multiple imports, independent dispose', async () => {
+    using baseline = await QuickJS.create(wasmBytes);
+    const obj = baseline.evalCode('({ tag: "kept" })');
+    const token = baseline.exportHandle(obj);
+    const snapshot = baseline.snapshot();
+    baseline.dispose();
+
+    using restored = await QuickJS.restore(snapshot, wasmBytes);
+    const first = restored.importHandle(token);
+    const second = restored.importHandle(token);
+    expect(first.getProp('tag').consume((h) => h.toString())).toBe('kept');
+    first.dispose();
+    // Disposing one import must not free the value out from under others.
+    expect(second.getProp('tag').consume((h) => h.toString())).toBe('kept');
+    second.dispose();
+    // The exported box's own reference keeps the value alive regardless.
+    using third = restored.importHandle(token);
+    expect(third.getProp('tag').consume((h) => h.toString())).toBe('kept');
+  });
+
+  it('round-trips on the same VM without a snapshot', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using original = vm.evalCode('({ n: 7 })');
+    const token = vm.exportHandle(original);
+    using imported = vm.importHandle(token);
+    expect(imported.getProp('n').consume((h) => h.toNumber())).toBe(7);
+    // Same underlying guest object.
+    expect(imported.identity).toBe(original.identity);
+  });
+
+  it('rejects handles from a different VM and disposed handles', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using other = await QuickJS.create(wasmBytes);
+    using foreign = other.evalCode('({})');
+    expect(() => vm.exportHandle(foreign)).toThrow('different VM');
+
+    const gone = vm.evalCode('({})');
+    gone.dispose();
+    expect(() => vm.exportHandle(gone)).toThrow('disposed');
+  });
+
+  it('serialized snapshots preserve token validity', async () => {
+    using baseline = await QuickJS.create(wasmBytes);
+    const value = baseline.evalCode('"portable\\u0000value"');
+    const token = baseline.exportHandle(value);
+    const bytes = QuickJS.serializeSnapshot(baseline.snapshot());
+    baseline.dispose();
+
+    using restored = await QuickJS.restore(
+      QuickJS.deserializeSnapshot(bytes),
+      wasmBytes
+    );
+    using imported = restored.importHandle(token);
+    expect(imported.length).toBe('portable\u0000value'.length);
+  });
+});

--- a/test/portable-handles.test.ts
+++ b/test/portable-handles.test.ts
@@ -69,6 +69,39 @@ describe('exportHandle / importHandle', () => {
     expect(imported.identity).toBe(original.identity);
   });
 
+  it('rejects borrowed handles (host-callback arguments)', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    let thrown: unknown;
+    let dupToken: number | undefined;
+    using fn = vm.newEphemeralFunction((arg) => {
+      // The trampoline's argument handles wrap C-owned boxes freed when
+      // this callback returns — a token minted from one would dangle in
+      // every restored VM.
+      try {
+        vm.exportHandle(arg);
+      } catch (err) {
+        thrown = err;
+      }
+      // The documented escape hatch: dup() (an owned box) exports fine.
+      const owned = arg.dup();
+      dupToken = vm.exportHandle(owned);
+      return vm.undefined;
+    });
+    vm.setProp(vm.global, 'cb', fn);
+    vm.evalCode('cb({ n: 3 })').dispose();
+    expect(String(thrown)).toContain('borrowed');
+    expect(dupToken).toBeDefined();
+    using imported = vm.importHandle(dupToken as number);
+    expect(imported.getProp('n').consume((h) => h.toNumber())).toBe(3);
+  });
+
+  it('rejects malformed tokens before dereferencing', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    for (const bad of [0, -1, 1.5, Number.NaN, 2 ** 40]) {
+      expect(() => vm.importHandle(bad)).toThrow('invalid token');
+    }
+  });
+
   it('rejects handles from a different VM and disposed handles', async () => {
     using vm = await QuickJS.create(wasmBytes);
     using other = await QuickJS.create(wasmBytes);


### PR DESCRIPTION
Companion to the snapshot/restore feature, motivated by vercel/workflow#3342's baseline-snapshot review cycle.

## Problem

Restore-side code that needs references to guest values captured at snapshot time (the headline case: pristine intrinsics captured BEFORE user code ran) has two bad options today: re-run the capture code in the restored VM — which executes guest-reachable code that user-patched globals can observe and perturb (a stateful wrapper around `Object.getOwnPropertyDescriptor` was demonstrated diverging fresh vs restored replays in vercel/workflow#3342) — or construct `JSValueHandle` directly from a recorded pointer, relying on internal knowledge that handle boxes live in the snapshot's memory image at stable offsets.

## API

- `vm.exportHandle(handle): number` — opaque snapshot-portable token (validates VM ownership + liveness). The handle must remain undisposed until after `snapshot()`.
- `vm.importHandle(token): JSValueHandle` — re-materializes an owned handle on this VM or any VM restored from a qualifying snapshot, by duplicating the underlying value. Callable any number of times; each result independently owned; **no guest code executes**. The exported box's own reference is intentionally retained per VM image (reclaimed with the VM).

## Tests

Five cases: pristine-intrinsic capture across snapshot/restore against a heap where user code patched the same intrinsic (the imported handle is the pristine function; the guest still sees its patch), multiple independent imports with independent dispose, same-VM round trip with identity equality, foreign-VM/disposed-handle rejection, and token validity through `serializeSnapshot`/`deserializeSnapshot`. Full suite: 1897 passed.