### PR TITLE
fix: throw InternalError: out of memory on memoryLimit exhaustion, not null

### DIFF
--- a/.changeset/oom-internal-error-not-null.md
+++ b/.changeset/oom-internal-error-not-null.md
@@ -2,4 +2,4 @@
 'quickjs-wasi': patch
 ---
 
-`memoryLimit` exhaustion throws `InternalError: out of memory` again instead of a bare `null` (regression in 3.3.1). Once allocation accounting became real, a guest at the limit left no room for the engine to allocate the "out of memory" InternalError itself, so quickjs fell back to throwing `JS_NULL` — in-guest `catch (e)` received `null` and the host `JSException` had name/message `"<null>"`. The limit is now enforced in the WASI malloc layer with reserved headroom below `memoryLimit` for constructing (and inspecting) the OOM error; the configured `memoryLimit` remains a hard ceiling.
+Exceeding `memoryLimit` throws `InternalError: out of memory` again instead of a bare `null` (regression in 3.3.1): the limit is now enforced in the WASI malloc layer, which reserves headroom below the limit so the OOM error object can always be constructed.

--- a/.changeset/oom-internal-error-not-null.md
+++ b/.changeset/oom-internal-error-not-null.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': patch
+---
+
+`memoryLimit` exhaustion throws `InternalError: out of memory` again instead of a bare `null` (regression in 3.3.1). Once allocation accounting became real, a guest at the limit left no room for the engine to allocate the "out of memory" InternalError itself, so quickjs fell back to throwing `JS_NULL` — in-guest `catch (e)` received `null` and the host `JSException` had name/message `"<null>"`. The limit is now enforced in the WASI malloc layer with reserved headroom below `memoryLimit` for constructing (and inspecting) the OOM error; the configured `memoryLimit` remains a hard ceiling.

--- a/c/interface.c
+++ b/c/interface.c
@@ -288,25 +288,101 @@ const char *qjs_get_quickjs_version(void) {
  *
  * wasi-libc's dlmalloc exports `malloc_usable_size`, so wiring it in
  * makes the accounting — and therefore `memoryLimit` — actually work.
+ *
+ * ---- Why the limit is enforced HERE and not via JS_SetMemoryLimit ----
+ *
+ * The engine's limit check (js_malloc_rt et al.) runs BEFORE the malloc
+ * functions are called and refuses at exactly malloc_limit. When a guest
+ * exhausts the limit with many small allocations, JS_ThrowOutOfMemory's
+ * own allocation of the "out of memory" InternalError object is refused
+ * too, and quickjs falls back to throwing a bare JS_NULL (issue #38) —
+ * in-guest `catch (e)` sees `null`, indistinguishable from `throw null`,
+ * and the host gets a nameless, messageless exception.
+ *
+ * So the engine-level malloc_limit is left unlimited, and the limit is
+ * enforced in these malloc functions instead: normal allocations are
+ * refused at a SOFT limit that sits QJS_OOM_HEADROOM below the
+ * configured memoryLimit. Once a refusal happens, allocations may dip
+ * into the reserved headroom (up to the full memoryLimit) so that the
+ * InternalError object — and the guest/host code that inspects it — can
+ * allocate. The reserve re-arms as soon as usage drops back below the
+ * soft limit, and the configured memoryLimit remains a hard ceiling at
+ * all times.
  */
+
+#define QJS_OOM_HEADROOM (64 * 1024)
+
+static size_t qjs_mem_limit = 0; /* 0 = unlimited */
+static size_t qjs_mem_used = 0;  /* sum of malloc_usable_size of live allocs */
+static int qjs_mem_in_oom = 0;   /* a refusal happened; headroom is open */
+
+/* The limit normal allocations are held to: memoryLimit minus the OOM
+   headroom (or half the limit when the limit is tiny). */
+static size_t qjs_mem_soft_limit(void) {
+    if (qjs_mem_limit > 2 * QJS_OOM_HEADROOM)
+        return qjs_mem_limit - QJS_OOM_HEADROOM;
+    return qjs_mem_limit / 2;
+}
+
+/* Overflow-safe: would qjs_mem_used + size exceed cap? */
+static int qjs_mem_exceeds(size_t size, size_t cap) {
+    return size > cap || qjs_mem_used > cap - size;
+}
+
+/*
+ * Returns non-zero if an allocation of `size` additional bytes must be
+ * refused. Opens the OOM headroom on refusal; re-arms it once usage fits
+ * under the soft limit again.
+ */
+static int qjs_mem_refuse(size_t size) {
+    if (qjs_mem_limit == 0)
+        return 0; /* unlimited */
+    if (!qjs_mem_exceeds(size, qjs_mem_soft_limit())) {
+        qjs_mem_in_oom = 0; /* healthy again: re-arm the reserve */
+        return 0;
+    }
+    if (qjs_mem_in_oom && !qjs_mem_exceeds(size, qjs_mem_limit))
+        return 0; /* constructing/handling the OOM error: use the reserve */
+    qjs_mem_in_oom = 1;
+    return 1;
+}
+
 static void *qjs_wasi_calloc(void *opaque, size_t count, size_t size) {
     (void)opaque;
-    return calloc(count, size);
+    /* quickjs checks count*size for overflow before calling us */
+    if (qjs_mem_refuse(count * size)) return NULL;
+    void *ptr = calloc(count, size);
+    if (ptr) qjs_mem_used += malloc_usable_size(ptr);
+    return ptr;
 }
 
 static void *qjs_wasi_malloc(void *opaque, size_t size) {
     (void)opaque;
-    return malloc(size);
+    if (qjs_mem_refuse(size)) return NULL;
+    void *ptr = malloc(size);
+    if (ptr) qjs_mem_used += malloc_usable_size(ptr);
+    return ptr;
 }
 
 static void qjs_wasi_free(void *opaque, void *ptr) {
     (void)opaque;
+    if (!ptr) return;
+    size_t usable = malloc_usable_size(ptr);
+    qjs_mem_used -= usable <= qjs_mem_used ? usable : qjs_mem_used;
     free(ptr);
 }
 
 static void *qjs_wasi_realloc(void *opaque, void *ptr, size_t size) {
     (void)opaque;
-    return realloc(ptr, size);
+    size_t old_usable = ptr ? malloc_usable_size(ptr) : 0;
+    size_t growth = size > old_usable ? size - old_usable : 0;
+    if (qjs_mem_refuse(growth)) return NULL;
+    void *new_ptr = realloc(ptr, size);
+    if (new_ptr) {
+        qjs_mem_used -= old_usable <= qjs_mem_used ? old_usable : qjs_mem_used;
+        qjs_mem_used += malloc_usable_size(new_ptr);
+    }
+    return new_ptr;
 }
 
 static size_t qjs_wasi_malloc_usable_size(const void *ptr) {
@@ -434,7 +510,15 @@ void qjs_set_module_loader(int enable) {
 
 __attribute__((export_name("qjs_set_memory_limit")))
 void qjs_set_memory_limit(size_t limit) {
-    if (rt) JS_SetMemoryLimit(rt, limit);
+    qjs_mem_limit = limit;
+    qjs_mem_in_oom = 0;
+    /* The limit is enforced by our malloc functions (see the comment above
+       qjs_wasi_malloc): the engine-level check refuses at exactly the limit
+       and leaves no headroom to construct the "out of memory" InternalError,
+       so a bare `null` gets thrown instead (issue #38). Keep the engine
+       limit unlimited — and explicitly reset it, since a runtime restored
+       from a snapshot may carry a persisted engine-level limit. */
+    if (rt) JS_SetMemoryLimit(rt, 0);
 }
 
 __attribute__((export_name("qjs_set_max_stack_size")))
@@ -481,7 +565,9 @@ void qjs_compute_memory_usage(int64_t *out) {
     JSMemoryUsage s;
     JS_ComputeMemoryUsage(rt, &s);
     out[0]  = s.malloc_size;
-    out[1]  = s.malloc_limit;
+    /* The engine-level malloc_limit is intentionally left unlimited (see
+       qjs_set_memory_limit); report the limit we actually enforce. */
+    out[1]  = (int64_t)qjs_mem_limit;
     out[2]  = s.memory_used_size;
     out[3]  = s.malloc_count;
     out[4]  = s.memory_used_count;

--- a/c/interface.c
+++ b/c/interface.c
@@ -375,12 +375,23 @@ static void qjs_wasi_free(void *opaque, void *ptr) {
 static void *qjs_wasi_realloc(void *opaque, void *ptr, size_t size) {
     (void)opaque;
     size_t old_usable = ptr ? malloc_usable_size(ptr) : 0;
+    /* Only consult the limiter when the block grows: a shrinking or
+       same-size realloc releases (or keeps) memory and must never be
+       refused — usage can legitimately sit above the soft limit, e.g.
+       right after qjs_set_memory_limit applies a tighter limit to a
+       restored snapshot, and refusing would turn a memory-RELEASING
+       operation into a spurious OOM. */
     size_t growth = size > old_usable ? size - old_usable : 0;
-    if (qjs_mem_refuse(growth)) return NULL;
+    if (growth > 0 && qjs_mem_refuse(growth)) return NULL;
     void *new_ptr = realloc(ptr, size);
     if (new_ptr) {
         qjs_mem_used -= old_usable <= qjs_mem_used ? old_usable : qjs_mem_used;
         qjs_mem_used += malloc_usable_size(new_ptr);
+    } else if (ptr && size == 0) {
+        /* Unreachable via quickjs (js_realloc_rt routes size==0 to
+           js_free_rt), but defensive: a libc whose realloc(ptr, 0) frees
+           and returns NULL must not leave the freed block accounted. */
+        qjs_mem_used -= old_usable <= qjs_mem_used ? old_usable : qjs_mem_used;
     }
     return new_ptr;
 }

--- a/test/limits.test.ts
+++ b/test/limits.test.ts
@@ -67,6 +67,49 @@ describe('memoryLimit', () => {
     expect(usage.mallocSize).toBeLessThanOrEqual(9 * 1024 * 1024);
   });
 
+  it('throws InternalError: out of memory, not null, on exhaustion (issue #38)', async () => {
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      memoryLimit: 4 * 1024 * 1024, // 4 MiB
+    });
+
+    // Regression: once #33 made the accounting real, a guest that filled
+    // memory with small objects left no room for JS_ThrowOutOfMemory to
+    // allocate the "out of memory" InternalError — the engine's limit
+    // check refused that allocation too, and quickjs fell back to
+    // throwing a bare JS_NULL. In-guest catch saw `null` and the host
+    // JSException had name/message "<null>", indistinguishable from a
+    // guest `throw null`. The malloc layer now reserves headroom below
+    // memoryLimit so the error object can always be constructed.
+    const result = vm.evalCode(`
+      (() => {
+        try {
+          const c = [];
+          for (;;) c.push({ i: c.length, s: 'x' + c.length });
+        } catch (e) {
+          return e === null ? 'NULL' : e.name + ': ' + e.message;
+        }
+      })()
+    `);
+    const msg = result.consume((h) => h.toString());
+    expect(msg).toBe('InternalError: out of memory');
+
+    // Uncaught OOM surfaces host-side with a real name/message too.
+    using vm2 = await QuickJS.create({
+      wasm: wasmBytes,
+      memoryLimit: 4 * 1024 * 1024,
+    });
+    try {
+      vm2.evalCode('const c = []; for (;;) c.push({ i: c.length })');
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(JSException);
+      expect((err as JSException).name).toBe('InternalError');
+      expect((err as JSException).message).toBe('out of memory');
+      (err as JSException).dispose();
+    }
+  });
+
   it('should allow normal operations within the limit', async () => {
     using vm = await QuickJS.create({
       wasm: wasmBytes,


### PR DESCRIPTION
Fixes #38

## Problem

Since 3.3.1, exhausting `memoryLimit` threw a bare `null` instead of `InternalError: out of memory` — in-guest `catch (e)` received `null` (indistinguishable from a guest `throw null`) and the host-side `JSException` had name/message `"<null>"`.

## Root cause

#33 made allocation accounting real (wiring wasi-libc's `malloc_usable_size` into the runtime's malloc functions). That fix was correct, but it exposed an engine-level footgun: quickjs-ng's limit check in `js_malloc_rt` runs **before** the malloc functions are called and refuses at exactly `malloc_limit`. When a guest fills memory with small allocations right up to the limit, `JS_ThrowOutOfMemory` → `JS_ThrowInternalError`'s own allocation of the error object is refused too, and `JS_ThrowError2` falls back to throwing a bare `JS_NULL` (quickjs-ng behaves the same way natively).

In 3.3.0 the accounting was broken (`malloc_size` ≈ 0), so the error-object allocation always passed the limit check — which is why the documented `InternalError: out of memory` used to surface.

## Fix

Enforce the limit in our WASI malloc layer instead of via `JS_SetMemoryLimit`:

- Normal allocations are refused at a **soft limit** 64 KiB below the configured `memoryLimit` (half the limit for tiny limits).
- Once a refusal happens, allocations may dip into the reserved headroom — bounded by the full `memoryLimit`, which remains a hard ceiling at all times — so the `InternalError` object (and the guest/host code that inspects it) can allocate.
- The reserve re-arms as soon as usage drops back below the soft limit.
- The engine-level `malloc_limit` stays unlimited, and is explicitly reset in `qjs_set_memory_limit` since a runtime restored from a snapshot may carry a persisted engine-level limit. `getMemoryUsage().mallocLimit` reports the enforced limit.

## Verification

Issue repro (4 MiB limit, small-object exhaustion):

- Before: `NULL`
- After: `InternalError: out of memory` (in-guest catch), and uncaught OOM surfaces host-side as `JSException` with `name === 'InternalError'`, `message === 'out of memory'`

Regression test added to `test/limits.test.ts` covering both the in-guest and host-side paths. Full suite passes against the rebuilt wasm: **1923/1923**.