### PR TITLE
feat: update quickjs-ng to v0.16.2

### DIFF
--- a/.changeset/engine-level-promise-then.md
+++ b/.changeset/engine-level-promise-then.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': patch
+---
+
+`resolvePromise()`, `Deferred.settled`, and module namespace resolution now subscribe via quickjs-ng's engine-level `JS_PromiseThen` instead of a captured `Promise.prototype.then`, so guest code that patches `then` or `Symbol.species` can no longer intercept or observe host promise subscriptions.

--- a/.changeset/handle-class-name.md
+++ b/.changeset/handle-class-name.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': minor
+---
+
+Add `handle.className`: the engine-level class name of a value (e.g. `"Map"`, `"Date"`, `"URL"`) read trap-free from the class table — unlike `constructorName`, it executes no guest code and cannot be spoofed by prototype/constructor reassignment.

--- a/.changeset/mark-promise-handled.md
+++ b/.changeset/mark-promise-handled.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': minor
+---
+
+Add `vm.markPromiseHandled(promise)`: suppress the `onUnhandledRejection` callback for a promise whose rejection the host observes through other means.

--- a/.changeset/quickjs-ng-0-16-2.md
+++ b/.changeset/quickjs-ng-0-16-2.md
@@ -1,0 +1,5 @@
+---
+'quickjs-wasi': minor
+---
+
+Update quickjs-ng from v0.15.1 to v0.16.2: brings the iterator chunking/includes/join proposals, the `Error.prototype.stack` accessor proposal, a faster register-based regexp engine, a new arena allocator, and many correctness/security fixes.

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ define wasm_opt
 endef
 
 # Compiler flags
+#
+# BUILDING_QJS_SHARED: since quickjs-ng 0.16 (commit 66adc82), JS_EXTERN only
+# carries default visibility when this is defined — without it, -fvisibility=hidden
+# hides the JS_* API from the dynamic symbol table and extension .so files can no
+# longer resolve them at runtime through -Wl,--export-dynamic.
 CFLAGS = \
 	--target=wasm32-wasip1 \
 	--sysroot=$(SYSROOT) \
@@ -65,6 +70,7 @@ CFLAGS = \
 	-D_WASI_EMULATED_PROCESS_CLOCKS \
 	-D_WASI_EMULATED_SIGNAL \
 	-DQJS_BUILD_LIBC=0 \
+	-DBUILDING_QJS_SHARED \
 	-fvisibility=hidden \
 	-Wall \
 	-Wno-implicit-fallthrough \

--- a/c/interface.c
+++ b/c/interface.c
@@ -751,10 +751,15 @@ uint8_t *qjs_compile(const char *code, size_t code_len, const char *filename,
        allocator is an arena whose pointers are NOT plain-malloc pointers,
        so hand out a plain-malloc copy and js_free the original. */
     uint8_t *copy = malloc(*out_len);
-    if (copy)
+    if (copy) {
         memcpy(copy, buf, *out_len);
-    else
+    } else {
+        /* The host reports a NULL return via the pending QuickJS
+           exception — make sure there is one, or it would surface a
+           stale/unset exception as the compile error. */
+        JS_ThrowOutOfMemory(ctx);
         *out_len = 0;
+    }
     js_free(ctx, buf);
     return copy; /* caller frees with wasm_free() */
 }

--- a/c/interface.c
+++ b/c/interface.c
@@ -87,7 +87,6 @@ static char *module_normalizer_trampoline(JSContext *ctx,
                                            const char *module_base_name,
                                            const char *module_name, void *opaque)
 {
-    (void)ctx;
     (void)opaque;
     char *result = host_module_normalize(module_base_name, module_name);
     if (!result) {
@@ -97,9 +96,18 @@ static char *module_normalizer_trampoline(JSContext *ctx,
             JS_ThrowReferenceError(ctx, "could not normalize module '%s'", module_name);
         return NULL;
     }
-    /* The host allocated with malloc; QuickJS expects js_malloc'd memory.
-       Since we're using the same allocator (wasi libc malloc), this is fine. */
-    return result;
+    /* The host allocated with plain malloc, but QuickJS frees the returned
+       name with js_free. Since quickjs-ng 0.16 the js_* allocator is an
+       arena that stores a block header BEFORE each pointer, so handing it
+       a foreign pointer reads a garbage header and corrupts the heap —
+       the two allocators can no longer be mixed. Copy into js_malloc'd
+       memory and free the host buffer. */
+    size_t len = strlen(result);
+    char *copy = js_malloc(ctx, len + 1);
+    if (copy)
+        memcpy(copy, result, len + 1);
+    free(result);
+    return copy; /* NULL on OOM: js_malloc already threw */
 }
 
 /*
@@ -647,6 +655,10 @@ static JSValue resolve_to_func_data(JSContext *ctx, JSValueConst this_val,
  * Rejections (e.g. a throw during module evaluation) propagate through
  * the chained promise unchanged.
  *
+ * The chaining uses JS_PromiseThen, the engine-level primitive that does
+ * not consult Promise.prototype.then or Symbol.species — guest code that
+ * patches either cannot intercept or observe module namespace resolution.
+ *
  * Consumes func_obj.
  */
 static JSValue eval_module_to_namespace(JSValue func_obj)
@@ -680,14 +692,7 @@ static JSValue eval_module_to_namespace(JSValue func_obj)
         return then_fn;
     }
 
-    JSAtom then_atom = JS_NewAtom(ctx, "then");
-    if (then_atom == JS_ATOM_NULL) {
-        JS_FreeValue(ctx, then_fn);
-        JS_FreeValue(ctx, eval_result);
-        return JS_EXCEPTION;
-    }
-    JSValue result = JS_Invoke(ctx, eval_result, then_atom, 1, &then_fn);
-    JS_FreeAtom(ctx, then_atom);
+    JSValue result = JS_PromiseThen(ctx, eval_result, then_fn, JS_UNDEFINED);
     JS_FreeValue(ctx, then_fn);
     JS_FreeValue(ctx, eval_result);
     return result;
@@ -737,7 +742,21 @@ uint8_t *qjs_compile(const char *code, size_t code_len, const char *filename,
     }
     uint8_t *buf = JS_WriteObject(ctx, out_len, obj, write_flags | JS_WRITE_OBJ_BYTECODE);
     JS_FreeValue(ctx, obj);
-    return buf; /* caller frees with js_free(ctx, buf) or wasm_free() */
+    if (!buf) {
+        *out_len = 0;
+        return NULL;
+    }
+    /* JS_WriteObject's buffer is js_malloc'd; the host frees the returned
+       pointer with wasm_free (plain free). Since quickjs-ng 0.16 the js_*
+       allocator is an arena whose pointers are NOT plain-malloc pointers,
+       so hand out a plain-malloc copy and js_free the original. */
+    uint8_t *copy = malloc(*out_len);
+    if (copy)
+        memcpy(copy, buf, *out_len);
+    else
+        *out_len = 0;
+    js_free(ctx, buf);
+    return copy; /* caller frees with wasm_free() */
 }
 
 /*
@@ -1021,6 +1040,35 @@ int qjs_get_class_id(JSValue *val) {
 }
 
 /*
+ * Get the engine-level class name of a value as a JS string — e.g.
+ * "Object", "Map", "Date", or the registered name of a class defined by
+ * an extension. Like the brand checks above this is trap-free: it reads
+ * the class table, so no Symbol.toStringTag lookups, constructor/name
+ * property reads, proxy traps, or prototype-chain walks — and it cannot
+ * be spoofed by guest code. Note the engine registers the Proxy class
+ * under the name "Object" (mirroring Object.prototype.toString); use
+ * qjs_is_proxy to detect proxies.
+ *
+ * Returns a heap-allocated JSValue*: a string, or JS_UNDEFINED for
+ * non-objects and for internal classes with no name.
+ *
+ * Requires quickjs-ng >= 0.16.2: earlier versions' JS_GetClassName
+ * returned the class id reinterpreted as an atom (garbage).
+ */
+__attribute__((export_name("qjs_get_class_name")))
+JSValue *qjs_get_class_name(JSValue *val) {
+    JSClassID class_id = JS_GetClassID(*val);
+    if (class_id == JS_INVALID_CLASS_ID)
+        return jsvalue_to_heap(JS_UNDEFINED);
+    JSAtom atom = JS_GetClassName(rt, class_id);
+    if (atom == JS_ATOM_NULL)
+        return jsvalue_to_heap(JS_UNDEFINED);
+    JSValue name = JS_AtomToString(ctx, atom);
+    JS_FreeAtom(ctx, atom);
+    return jsvalue_to_heap(name);
+}
+
+/*
  * Get the [[ProxyTarget]] of a Proxy, without firing any traps.
  * Returns a heap-allocated JSValue*, or JS_EXCEPTION if the value
  * is not a Proxy.
@@ -1208,6 +1256,31 @@ int qjs_promise_state(JSValue *promise) {
 __attribute__((export_name("qjs_promise_result")))
 JSValue *qjs_promise_result(JSValue *promise) {
     return jsvalue_to_heap(JS_PromiseResult(ctx, *promise));
+}
+
+/*
+ * Subscribe to a promise via the engine-level primitive: JS_PromiseThen
+ * does not consult Promise.prototype.then or Symbol.species, so guest
+ * code that patches either cannot intercept the subscription or swap in
+ * a foreign "promise". Returns a heap-allocated JSValue* holding the
+ * chained promise, or JS_EXCEPTION if the value is not a promise.
+ *
+ * Pass a JS_UNDEFINED handle for an absent on_fulfilled/on_rejected
+ * handler (spec pass-through behavior).
+ */
+__attribute__((export_name("qjs_promise_then")))
+JSValue *qjs_promise_then(JSValue *promise, JSValue *on_fulfilled, JSValue *on_rejected) {
+    return jsvalue_to_heap(JS_PromiseThen(ctx, *promise, *on_fulfilled, *on_rejected));
+}
+
+/*
+ * Mark a promise as handled: an eventual (or past) rejection will not be
+ * reported to the host promise-rejection tracker. No-op for non-promises.
+ */
+__attribute__((export_name("qjs_promise_mark_as_handled")))
+void qjs_promise_mark_as_handled(JSValue *promise) {
+    if (!JS_IsPromise(*promise)) return;
+    JS_PromiseMarkAsHandled(ctx, *promise);
 }
 
 /* ---- Job Queue ---- */

--- a/examples/browser/main.tsx
+++ b/examples/browser/main.tsx
@@ -389,22 +389,27 @@ const jsValueAccessor: DataAccessor = {
 
   getConstructorName(value: unknown): string | undefined {
     const h = value as JSValueHandle;
-    // Reading .constructor.name on a Proxy would fire its get trap
+    // Reading .constructor.name on a Proxy would fire its get trap. The
+    // engine registers the Proxy class as "Object", so this must come
+    // before the className read.
     if (h.isProxy) return 'Proxy';
 
-    // Prefer the engine brand: `.constructor.name` is two [[Get]]s that can
-    // run guest getters, and it is trivially spoofed (`{ constructor: Map }`
-    // reports "Map"). The brand cannot be forged or patched.
-    if (h.isMap) return 'Map';
-    if (h.isSet) return 'Set';
-    if (h.isDate) return 'Date';
-    if (h.isRegExp) return 'RegExp';
-    if (h.isWeakMap) return 'WeakMap';
-    if (h.isWeakSet) return 'WeakSet';
-    if (h.isWeakRef) return 'WeakRef';
-    if (h.isDataView) return 'DataView';
-    if (h.isArrayBuffer) return 'ArrayBuffer';
-    if (h.isPromise) return 'Promise';
+    // Prefer the engine's class table: `className` is a trap-free,
+    // unspoofable read that labels every registered class — including the
+    // typed arrays and extension-defined classes (URL, Headers,
+    // TextEncoder, …) the previous hand-rolled brand ladder missed.
+    // Generic names fall through: "Object"/"Function" so user classes get
+    // their real name from the prototype, and "Error" so TypeError
+    // instances (all native errors share the one Error class) do too.
+    const className = h.className;
+    if (
+      className !== undefined &&
+      className !== 'Object' &&
+      className !== 'Function' &&
+      className !== 'Error'
+    ) {
+      return className;
+    }
 
     // Unbranded: take the constructor from the *prototype*, never from the
     // value's own properties — `{ constructor: Map }` would otherwise be

--- a/src/index.ts
+++ b/src/index.ts
@@ -395,6 +395,7 @@ interface QuickJSExports {
   qjs_is_weak_set(valPtr: number): number;
   qjs_is_data_view(valPtr: number): number;
   qjs_get_class_id(valPtr: number): number;
+  qjs_get_class_name(valPtr: number): number;
   qjs_get_proxy_target(valPtr: number): number;
   qjs_get_proxy_handler(valPtr: number): number;
 
@@ -447,6 +448,8 @@ interface QuickJSExports {
   qjs_new_promise(resolveOutPtr: number, rejectOutPtr: number): number;
   qjs_promise_state(promisePtr: number): number;
   qjs_promise_result(promisePtr: number): number;
+  qjs_promise_then(promisePtr: number, onFulfilledPtr: number, onRejectedPtr: number): number;
+  qjs_promise_mark_as_handled(promisePtr: number): void;
 
   // Job queue
   qjs_is_job_pending(): number;
@@ -577,9 +580,6 @@ export class QuickJS {
    * @internal
    */
   _activeScope: Set<JSValueHandle> | null = null;
-
-  /** `Promise.prototype.then`, captured on first use. @internal */
-  private _promiseThen: JSValueHandle | null = null;
 
   /** Loaded extensions in deterministic order */
   private loadedExtensions: LoadedExtension[] = [];
@@ -1756,15 +1756,8 @@ export class QuickJS {
             return vm.undefined;
           });
 
-          const onSettleDup = onSettleFn.dup();
-          vm.callFunctionRaw(
-            vm.getPromiseThen(),
-            promiseHandle,
-            onSettleFn,
-            onSettleDup
-          ).dispose();
+          vm.promiseThenRaw(promiseHandle, onSettleFn, onSettleFn).dispose();
           onSettleFn.dispose();
-          onSettleDup.dispose();
         }
         return _settled;
       },
@@ -1829,38 +1822,38 @@ export class QuickJS {
         return this.undefined;
       });
 
-      // Use the captured intrinsic rather than reading `.then` off the value:
-      // a proxy or a patched own property would otherwise run guest code here.
-      this.callFunctionRaw(
-        this.getPromiseThen(),
-        promiseHandle,
-        onFulfilled,
-        onRejected
-      ).dispose();
+      // Subscribe via the engine-level primitive: JS_PromiseThen does not
+      // consult Promise.prototype.then or Symbol.species, so guest code
+      // that patches either cannot intercept the subscription (or run at
+      // all during it).
+      this.promiseThenRaw(promiseHandle, onFulfilled, onRejected).dispose();
       onFulfilled.dispose();
       onRejected.dispose();
     });
   }
 
   /**
-   * `Promise.prototype.then`, captured once and reused.
-   *
-   * `resolvePromise()` needs to subscribe to a promise without executing
-   * guest code, so it must not read `.then` off the value being resolved.
+   * Subscribe to a promise without executing guest code, via quickjs-ng's
+   * JS_PromiseThen: no Promise.prototype.then lookup, no Symbol.species.
+   * Returns the chained promise. Handler handles are borrowed (caller
+   * still owns and disposes them).
+   * @internal
    */
-  /** @internal */
-  getPromiseThen(): JSValueHandle {
-    if (!this._promiseThen) {
-      // capture outside any active scope, since this outlives it
-      const enclosing = this._activeScope;
-      this._activeScope = null;
-      try {
-        this._promiseThen = this.evalCode('Promise.prototype.then');
-      } finally {
-        this._activeScope = enclosing;
-      }
-    }
-    return this._promiseThen;
+  promiseThenRaw(promise: JSValueHandle, onFulfilled: JSValueHandle, onRejected: JSValueHandle): JSValueHandle {
+    return new JSValueHandle(this, this.exports.qjs_promise_then(promise.ptr, onFulfilled.ptr, onRejected.ptr));
+  }
+
+  /**
+   * Mark a promise as handled: an eventual (or already-recorded) rejection
+   * will not be reported to `onUnhandledRejection`. Useful when the host
+   * observes a rejection through other means (e.g. `resolvePromise()`) and
+   * wants to suppress the unhandled-rejection callback for it.
+   *
+   * No-op if the handle is not a promise.
+   */
+  markPromiseHandled(promise: JSValueHandle): void {
+    this.assertNotDisposed();
+    this.exports.qjs_promise_mark_as_handled(promise.ptr);
   }
 
   /**
@@ -2333,7 +2326,6 @@ export class QuickJS {
       this._ownedHandles.clear();
       this.hostCallbacks.clear();
       this._activeScope = null;
-      this._promiseThen = null;
       this.exports = null!;
       this.instance = null!;
       this.module = null!;
@@ -2799,6 +2791,29 @@ export class JSValueHandle {
    */
   get classId(): number {
     return this.vm._getExports().qjs_get_class_id(this.ptr);
+  }
+
+  /**
+   * The engine-level class name of this value — e.g. `"Object"`, `"Map"`,
+   * `"Date"`, `"RegExp"`, or the registered name of an extension-defined
+   * class like `"URL"` — or `undefined` for non-objects and unnamed
+   * internal classes.
+   *
+   * Unlike `constructorName` (which reads the `constructor` and `name`
+   * properties and can therefore fire getters/proxy traps and be spoofed),
+   * this is trap-free: it reads the engine's class table directly, never
+   * executes guest code, and cannot be forged by reassigning prototypes or
+   * constructors. Note that the engine registers the Proxy class under the
+   * name `"Object"` (mirroring `Object.prototype.toString`) — use `isProxy`
+   * to detect proxies and `getProxyTarget()` to read the target's brand.
+   */
+  get className(): string | undefined {
+    const h = new JSValueHandle(this.vm, this.vm._getExports().qjs_get_class_name(this.ptr));
+    try {
+      return h.isUndefined ? undefined : h.toString();
+    } finally {
+      h.dispose();
+    }
   }
 
   get promiseState(): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2809,6 +2809,14 @@ export class JSValueHandle {
    */
   get className(): string | undefined {
     const h = new JSValueHandle(this.vm, this.vm._getExports().qjs_get_class_name(this.ptr));
+    // qjs_get_class_name can return JS_EXCEPTION (e.g. OOM while
+    // materializing the name atom as a string); surface it instead of
+    // stringifying the exception sentinel and leaving the real error
+    // pending on the context.
+    if (this.vm._getExports().qjs_is_exception(h.ptr) !== 0) {
+      h.dispose();
+      throw new JSException(this.vm.getException());
+    }
     try {
       return h.isUndefined ? undefined : h.toString();
     } finally {

--- a/test/devalue-operations.ts
+++ b/test/devalue-operations.ts
@@ -10,7 +10,8 @@
  * Two halves, mirroring devalue's two pluggable operation sets:
  *
  * - `stringifyOperations` reads a handle without executing guest code:
- *   engine-level brand checks for classification, boot-captured intrinsics
+ *   the engine's class table for classification (`handle.className` — no
+ *   sample instances needed, not even at boot), boot-captured intrinsics
  *   for extraction, and descriptor reads instead of `[[Get]]`.
  * - `parseOperations` builds values inside the VM through boot-captured
  *   factories, returning a handle the guest can use directly.
@@ -28,31 +29,38 @@ import {
 } from 'devalue';
 import { QuickJS, type JSValueHandle } from '../src/index.ts';
 
-/** Tags devalue classifies values by, keyed on QuickJS class id. */
-const BRANDED_SAMPLES = `({
-  Number: new Number(0),
-  String: new String(''),
-  Boolean: new Boolean(false),
-  BigInt: Object(0n),
-  Date: new Date(0),
-  RegExp: /x/,
-  Array: [],
-  Set: new Set(),
-  Map: new Map(),
-  ArrayBuffer: new ArrayBuffer(0),
-  DataView: new DataView(new ArrayBuffer(0)),
-  Int8Array: new Int8Array(0),
-  Uint8Array: new Uint8Array(0),
-  Uint8ClampedArray: new Uint8ClampedArray(0),
-  Int16Array: new Int16Array(0),
-  Uint16Array: new Uint16Array(0),
-  Int32Array: new Int32Array(0),
-  Uint32Array: new Uint32Array(0),
-  Float32Array: new Float32Array(0),
-  Float64Array: new Float64Array(0),
-  BigInt64Array: new BigInt64Array(0),
-  BigUint64Array: new BigUint64Array(0),
-})`;
+/**
+ * The tags devalue classifies values by. QuickJS registers each of these
+ * classes under exactly this name, so `handle.className` — a trap-free
+ * read of the engine's class table (`JS_GetClassName`, fixed in
+ * quickjs-ng 0.16.2) — classifies values directly. No sample instances,
+ * no guest code, not even at boot: a VM built without some of these
+ * intrinsics classifies the rest just fine.
+ */
+const BRANDED_TAGS = new Set([
+  'Number',
+  'String',
+  'Boolean',
+  'BigInt',
+  'Date',
+  'RegExp',
+  'Array',
+  'Set',
+  'Map',
+  'ArrayBuffer',
+  'DataView',
+  'Int8Array',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Int16Array',
+  'Uint16Array',
+  'Int32Array',
+  'Uint32Array',
+  'Float32Array',
+  'Float64Array',
+  'BigInt64Array',
+  'BigUint64Array',
+]);
 
 /**
  * Everything the host needs from the guest realm, captured once at boot.
@@ -150,15 +158,6 @@ export function createDevalueOperations(vm: QuickJS): DevalueOperations {
   };
 
   // --- boot-time capture -------------------------------------------------
-
-  const tagByClassId = new Map<number, string>();
-  {
-    using samples = vm.evalCode(BRANDED_SAMPLES);
-    for (const tag of samples.getOwnPropertyNames()) {
-      using sample = samples.getProp(tag);
-      tagByClassId.set(sample.classId, tag);
-    }
-  }
 
   const intrinsics = keep(vm.evalCode(CAPTURE_INTRINSICS));
   const at = (name: string) => keep(intrinsics.getProp(name));
@@ -280,10 +279,12 @@ export function createDevalueOperations(vm: QuickJS): DevalueOperations {
   };
 
   const tag = (handle: JSValueHandle): string => {
-    // A proxy is never one of the branded types; report it as a plain-object
-    // candidate so `shapeOf` can reject it without firing traps.
-    if (handle.isProxy) return 'Object';
-    return tagByClassId.get(handle.classId) ?? 'Object';
+    // Trap-free and unspoofable: the engine's registered class name.
+    // Everything unbranded — including proxies, whose class is registered
+    // as "Object" — reports as a plain-object candidate, which `shapeOf`
+    // then accepts or rejects without firing traps.
+    const name = handle.className;
+    return name !== undefined && BRANDED_TAGS.has(name) ? name : 'Object';
   };
 
   /** Collect the elements a Set/Map yields, via captured `forEach`. */

--- a/test/devalue-round-trip.test.ts
+++ b/test/devalue-round-trip.test.ts
@@ -427,6 +427,58 @@ describe('host-side devalue: guest code is not executed', () => {
     }
   });
 
+  it('classifies via the engine class table, surviving constructor sabotage', async () => {
+    const harness = await createHarness();
+    try {
+      using value = harness.vm.evalCode(`(() => {
+        const value = {
+          bytes: new Uint8Array([1, 2, 3]),
+          when: new Date(1700000000000),
+          map: new Map([['k', 'v']]),
+        };
+        // Post-boot sabotage: classification must not depend on any of it.
+        globalThis.Uint8Array = undefined;
+        globalThis.Date = undefined;
+        globalThis.Map = undefined;
+        Object.defineProperty(value.map.constructor?.prototype ?? {}, 'x', { value: 1 });
+        return value;
+      })()`);
+
+      expect(harness.serialize(value)).toBe(
+        stringify({
+          bytes: new Uint8Array([1, 2, 3]),
+          when: new Date(1700000000000),
+          map: new Map([['k', 'v']]),
+        })
+      );
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it('is not fooled by prototype swaps in either direction', async () => {
+    const harness = await createHarness();
+    try {
+      // A plain object dressed up as a typed array is still not one: it
+      // classifies as an object, and its foreign prototype makes it
+      // non-plain, so serialization refuses rather than fabricating bytes.
+      using fake = harness.vm.evalCode(
+        'Object.setPrototypeOf({ a: 1 }, Uint8Array.prototype)'
+      );
+      expect(() => harness.serialize(fake)).toThrow(/non-POJO/);
+
+      // A real typed array stripped of its prototype keeps its internal
+      // slots — the class table still says Uint8Array and the captured
+      // getters read the real buffer.
+      using stripped = harness.vm.evalCode(
+        'Object.setPrototypeOf(new Uint8Array([7, 8]), Object.prototype)'
+      );
+      expect(harness.serialize(stripped)).toBe(stringify(new Uint8Array([7, 8])));
+    } finally {
+      harness.dispose();
+    }
+  });
+
   it('rejects an object with enumerable symbol keys, without reading them', async () => {
     const harness = await createHarness();
     try {

--- a/test/introspection.test.ts
+++ b/test/introspection.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { QuickJS, type JSValueHandle } from '../src/index.ts';
 import { wasmBytes } from './helpers.ts';
 
@@ -223,6 +224,74 @@ describe('classId', () => {
     expect(map1.classId).toBe(map2.classId);
     expect(set.classId).toBeGreaterThan(0);
     expect(set.classId).not.toBe(map1.classId);
+  });
+});
+
+describe('className', () => {
+  it('returns the engine-level class name for objects, undefined for non-objects', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    for (const [expression, expected] of [
+      ['({})', 'Object'],
+      ['[]', 'Array'],
+      ['new Map()', 'Map'],
+      ['new Set()', 'Set'],
+      ['new Date(0)', 'Date'],
+      ['/x/', 'RegExp'],
+      ['new Error("boom")', 'Error'],
+      ['Promise.resolve()', 'Promise'],
+      ['(() => {})', 'Function'],
+      ['42', undefined],
+      ['"str"', undefined],
+      ['null', undefined],
+      ['undefined', undefined],
+    ] as const) {
+      using handle = vm.evalCode(expression);
+      expect(handle.className, expression).toBe(expected);
+    }
+  });
+
+  it('cannot be spoofed by reassigning prototypes or constructors', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using fakeMap = vm.evalCode(`
+      const o = { constructor: { name: 'Map' } };
+      Object.setPrototypeOf(o, Map.prototype);
+      o
+    `);
+    // constructorName is fooled; className is not
+    expect(fakeMap.constructorName).toBe('Map');
+    expect(fakeMap.className).toBe('Object');
+  });
+
+  it('fires zero traps on proxies; the unwrapped target reports its brand', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using proxy = vm.evalCode(`
+      globalThis.trapCount = 0;
+      const countingHandler = new Proxy({}, {
+        get(t, prop) { globalThis.trapCount++; return undefined; }
+      });
+      new Proxy(new Map(), countingHandler)
+    `);
+
+    // The engine registers the Proxy class under the name "Object"
+    // (mirroring Object.prototype.toString) — use isProxy to detect
+    // proxies, then unwrap to get the real brand.
+    expect(proxy.className).toBe('Object');
+    expect(proxy.isProxy).toBe(true);
+    using target = proxy.getProxyTarget();
+    expect(target.className).toBe('Map');
+
+    using count = vm.evalCode('globalThis.trapCount');
+    expect(count.toNumber()).toBe(0);
+  });
+
+  it('reports extension-defined classes', async () => {
+    const urlExtBytes = readFileSync(new globalThis.URL('../extensions/url/url.so', import.meta.url));
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      extensions: [{ name: 'url', wasm: urlExtBytes }],
+    });
+    using url = vm.evalCode('new URL("https://example.com/")');
+    expect(url.className).toBe('URL');
   });
 });
 

--- a/test/promise-rejection.test.ts
+++ b/test/promise-rejection.test.ts
@@ -117,3 +117,38 @@ describe('onUnhandledRejection', () => {
     expect(rejections).toContain('post-restore');
   });
 });
+
+describe('markPromiseHandled', () => {
+  it('suppresses the unhandled-rejection callback for a marked promise', async () => {
+    const rejections: string[] = [];
+
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      onUnhandledRejection: (_promise, reason, isHandled) => {
+        if (!isHandled) rejections.push(reason.toString());
+      },
+    });
+
+    // A pending promise that will reject in a later microtask
+    using promise = vm.evalCode(`
+      globalThis.trigger = null;
+      new Promise((_, reject) => { globalThis.trigger = reject; })
+    `);
+    vm.markPromiseHandled(promise);
+
+    vm.evalCode('trigger("suppressed")').dispose();
+    vm.executePendingJobs();
+    expect(rejections).not.toContain('suppressed');
+
+    // An unmarked rejection still fires, proving the tracker is active
+    vm.evalCode('Promise.reject("reported")').dispose();
+    vm.executePendingJobs();
+    expect(rejections).toContain('reported');
+  });
+
+  it('is a no-op for non-promise handles', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    using notAPromise = vm.evalCode('({})');
+    expect(() => vm.markPromiseHandled(notAPromise)).not.toThrow();
+  });
+});

--- a/test/promises.test.ts
+++ b/test/promises.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { QuickJS } from '../src/index.ts';
+import { QuickJS, EvalFlags } from '../src/index.ts';
 import { wasmBytes } from './helpers.ts';
 
 describe('newPromise / Deferred', () => {
@@ -71,5 +71,68 @@ describe('resolvePromise', () => {
       expect(result.value.toString()).toBe('just a string');
       result.value.dispose();
     }
+  });
+
+  it('cannot be intercepted by patching Promise.prototype.then or Symbol.species', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+
+    // Guest sabotages the prototype BEFORE the host ever touches a promise:
+    // the subscription goes through the engine-level JS_PromiseThen, which
+    // consults neither Promise.prototype.then nor Symbol.species.
+    vm.evalCode(`
+      globalThis.thenCalls = 0;
+      const realThen = Promise.prototype.then;
+      Promise.prototype.then = function (...args) {
+        globalThis.thenCalls++;
+        return realThen.apply(this, args);
+      };
+      Object.defineProperty(Promise, Symbol.species, {
+        get() { globalThis.thenCalls += 1000; return Promise; }
+      });
+    `).dispose();
+
+    using pending = vm.evalCode(`
+      globalThis.trigger = null;
+      new Promise((resolve) => { globalThis.trigger = resolve; })
+    `);
+    const resultPromise = vm.resolvePromise(pending);
+    vm.evalCode('trigger("untouched")').dispose();
+    vm.executePendingJobs();
+
+    const result = await resultPromise;
+    expect('value' in result).toBe(true);
+    if ('value' in result) {
+      expect(result.value.toString()).toBe('untouched');
+      result.value.dispose();
+    }
+
+    using calls = vm.evalCode('globalThis.thenCalls');
+    expect(calls.toNumber()).toBe(0);
+  });
+
+  it('module namespace resolution is not observable via patched then', async () => {
+    using vm = await QuickJS.create(wasmBytes);
+    vm.evalCode(`
+      globalThis.thenCalls = 0;
+      const realThen = Promise.prototype.then;
+      Promise.prototype.then = function (...args) {
+        globalThis.thenCalls++;
+        return realThen.apply(this, args);
+      };
+    `).dispose();
+
+    // Module evaluation chains eval_promise -> namespace in C via
+    // JS_PromiseThen; the patched then must not observe (or hijack) it.
+    using promise = vm.evalCode('export const x = 7;', '<mod>', EvalFlags.TYPE_MODULE);
+    vm.executePendingJobs();
+    const result = await vm.resolvePromise(promise);
+    expect('value' in result).toBe(true);
+    if ('value' in result) {
+      expect(result.value.getProp('x').consume(h => h.toNumber())).toBe(7);
+      result.value.dispose();
+    }
+
+    using calls = vm.evalCode('globalThis.thenCalls');
+    expect(calls.toNumber()).toBe(0);
   });
 });


### PR DESCRIPTION
Updates the quickjs-ng submodule from v0.15.1 to the latest release, v0.16.2, and exposes the new engine APIs that are relevant to the side-effect-free introspection efforts.

## Engine update (guest-visible highlights)

- Iterator proposals: chunking (`chunks`/`windows`), `includes`, `join`; `Iterator.concat` fixes
- `Error.prototype.stack` accessor proposal, `CallSite.prototype.isConstructor()`
- nonextensible-applies-to-private proposal
- Bellard's register-based regexp engine; interpreter arithmetic fast paths; arena allocator
- Many correctness / memory-safety fixes (use-after-free, leaks, OOB write in libregexp, TypedArray edge cases, module re-export crashes)

## Build/embedding breakages handled

1. **Extension symbol visibility** — since 0.16 (66adc82), `JS_EXTERN` only carries default visibility when `BUILDING_QJS_SHARED` is defined; with our `-fvisibility=hidden` the `JS_*` API disappeared from the dynamic symbol table and every extension `.so` failed with `called unresolved symbol: env.JS_GetGlobalObject`. Now defined in `CFLAGS`.

2. **Arena allocator vs. cross-allocator frees** — the new arena allocator (9de2921) stores a block header *before* every `js_malloc`'d pointer, so plain-`malloc` and `js_malloc` pointers are no longer interchangeable (previously benign because both bottomed out in dlmalloc). A foreign pointer handed to `js_free` reads a garbage header and corrupts the heap — caught as a `js_free_rt` abort in the dynamic-import path. Fixed the two mixing sites:
   - `module_normalizer_trampoline` copies the host's malloc'd name into `js_malloc`'d memory (quickjs frees the returned name with `js_free`)
   - `qjs_compile` hands the host a plain-malloc copy of the `JS_WriteObject` buffer (the TS side frees it with `wasm_free`)

## New APIs surfaced

- **`handle.className`** — engine-level class name (`"Map"`, `"Date"`, `"URL"`, …) read trap-free from the class table via `JS_GetClassName`, which 0.16.2 actually fixed (#1641: it previously returned the class id reinterpreted as an atom, i.e. garbage). Unlike `constructorName` it executes no guest code and cannot be spoofed by prototype/constructor reassignment. (Upstream registers the Proxy class as `"Object"`; `isProxy`/`getProxyTarget()` remain the proxy story.)
- **`vm.markPromiseHandled(promise)`** — via new `JS_PromiseMarkAsHandled`: suppress `onUnhandledRejection` for promises the host observes through other means.
- **Engine-level promise subscription** — `resolvePromise()`, `Deferred.settled`, and the C-side module-namespace chaining now use the new `JS_PromiseThen`, which consults neither `Promise.prototype.then` nor `Symbol.species`. This replaces the lazily-captured `Promise.prototype.then` (which a guest could patch *before* capture) and the atom-based `.then` invoke in `eval_module_to_namespace` — guest code can no longer intercept or observe host promise subscriptions or module namespace resolution. Covered by new interception-attempt tests.

## Verification

- Full suite passes against the rebuilt wasm + extensions: **1931/1931** (8 new tests: className semantics/spoof-resistance/zero-traps/extension classes, markPromiseHandled, then/species interception attempts)
- `vm.versions` reports `quickjs: 0.16.2`