### PR TITLE
docs: audit documentation and comments against the Vercel technical writing style

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -1,12 +1,12 @@
-# Native WASM Extensions
+# Native WASM extensions
 
-quickjs-wasi supports loading native C extensions compiled as WebAssembly shared libraries. Extensions link directly against the QuickJS C API through WASM dynamic linking: they share the same linear memory, function table, and heap allocator as the main QuickJS module, so there is zero marshalling overhead when calling QuickJS APIs.
+quickjs-wasi supports loading native C extensions compiled as WebAssembly shared libraries. Extensions link directly against the QuickJS C API through WASM dynamic linking: they share the same linear memory, function table, and heap allocator as the main QuickJS module, so there is zero marshaling overhead when calling QuickJS APIs.
 
 This enables implementing Web API polyfills (URL, FormData, Blob, etc.) and other performance-critical functionality in C rather than JavaScript, while keeping them loadable at runtime as separate `.so` files.
 
 ## Get started
 
-### Using a Built-in Extension
+### Using a built-in extension
 
 Each pre-built extension's compiled `.so` is exposed as a package sub-export. The caller is responsible for loading the bytes; quickjs-wasi never reads from disk or fetches over the network on your behalf:
 
@@ -59,7 +59,7 @@ const vm = await QuickJS.create({
 });
 ```
 
-### Building an Extension
+### Building an extension
 
 Extensions are C files that use the QuickJS C API, compiled with wasi-sdk as shared libraries:
 
@@ -114,9 +114,9 @@ const vm = await QuickJS.create({
 vm.evalCode('hello()').consume(h => h.toString()); // "Hello from a native extension!"
 ```
 
-## How It Works
+## How it works
 
-### WASM Dynamic Linking
+### WASM dynamic linking
 
 Extensions use the [WebAssembly dynamic linking convention](https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md). The main `quickjs.wasm` module is a statically-linked WASI reactor that exports:
 
@@ -139,7 +139,7 @@ Extensions are compiled as WASM shared libraries (`.so` files) with `-fPIC --sha
 
 Because all modules share the same linear memory, a `JSContext*` pointer in the extension points to the same struct that QuickJS is using, so there is no serialization or copying when calling QuickJS APIs.
 
-### Extension Init Function
+### Extension init function
 
 Each extension must export an init function. The default naming convention is `qjs_ext_<name>_init`, where `<name>` matches the `name` field in the `ExtensionDescriptor`. You can override this with the `initFn` option.
 
@@ -159,7 +159,7 @@ int qjs_ext_myext_init(JSContext *ctx, JSRuntime *rt) {
 }
 ```
 
-### Version Reporting
+### Version reporting
 
 Extensions can optionally export a `qjs_ext_<name>_versions` function to report version information for native libraries they bundle. This information is surfaced via `vm.versions` on the host side.
 
@@ -202,7 +202,7 @@ console.log(vm.versions);
 // }
 ```
 
-### Snapshot/Restore with Extensions
+### Snapshot/restore with extensions
 
 Extensions are fully compatible with the snapshot/restore system. The snapshot includes:
 
@@ -247,7 +247,7 @@ vm2.evalCode('new URL("https://other.com").hostname')
   .consume(h => h.toString()); // 'other.com'
 ```
 
-## Writing Extensions
+## Writing extensions
 
 ### Available APIs
 
@@ -272,7 +272,7 @@ Extensions can call any function exported by the main module. This includes:
 - Sorting: `qsort`, `bsearch`
 - Other: `strerror`, `abort`
 
-### Registering a Class
+### Registering a class
 
 The typical pattern for registering a custom class with opaque C data:
 
@@ -346,7 +346,7 @@ int qjs_ext_myext_init(JSContext *ctx, JSRuntime *rt) {
 }
 ```
 
-### Compiler Flags
+### Compiler flags
 
 | Flag | Purpose |
 |------|---------|
@@ -356,7 +356,7 @@ int qjs_ext_myext_init(JSContext *ctx, JSRuntime *rt) {
 | `--target=wasm32-wasip1` | WASI target |
 | `--sysroot=...` | wasi-sdk sysroot |
 
-### Linker Flags
+### Linker flags
 
 | Flag | Purpose |
 |------|---------|
@@ -365,7 +365,7 @@ int qjs_ext_myext_init(JSContext *ctx, JSRuntime *rt) {
 | `--export-dynamic` | Export all non-hidden symbols |
 | `--allow-undefined` | Allow unresolved symbols (resolved at load time against the main module) |
 
-## Built-in Extensions
+## Built-in extensions
 
 | Extension | Subpath | Provides |
 |-----------|---------|----------|
@@ -379,7 +379,7 @@ int qjs_ext_myext_init(JSContext *ctx, JSRuntime *rt) {
 
 See each extension's README for full API documentation.
 
-## WASI Override Layering
+## WASI override layering
 
 Extensions that import `wasi_snapshot_preview1` functions (like the crypto extension importing `random_get`) receive WASI implementations from a three-layer merge:
 
@@ -414,7 +414,7 @@ const vm = await QuickJS.create({
 });
 ```
 
-## Known Limitations
+## Known limitations
 
 ### Unstable ABI
 
@@ -426,33 +426,33 @@ wasm-ld: warning: creating shared libraries, with -shared, is not yet stable
 
 The `dylink.0` section format and GOT conventions could change in a future wasi-sdk release. In practice, the convention has been stable since ~2020 (Emscripten uses the same format), but there is no formal stability guarantee.
 
-### Same Toolchain Requirement
+### Same toolchain requirement
 
 The main module and all extensions **must be compiled with the same wasi-sdk version**. If you upgrade wasi-sdk and rebuild `quickjs.wasm`, you must also rebuild all extensions. There is no versioning mechanism to detect mismatches: struct layouts, calling conventions, and symbol mangling could silently differ between toolchain versions.
 
 The current build uses **wasi-sdk 32** (clang 22.1.0).
 
-### No LTO for Extensions
+### No LTO for extensions
 
 The main module uses link-time optimization (`-flto`), but extensions cannot, because LTO is incompatible with `-fPIC --shared` in wasi-sdk. Extension code will not be as aggressively optimized. For most extensions this is irrelevant, but compute-heavy extensions may notice a difference.
 
-### Limited GOT Resolution
+### Limited GOT resolution
 
 The loader resolves `GOT.func.*` entries by looking up functions in the main module's exports and adding them to the indirect function table. This allows extensions to call main-module functions via function pointers (e.g. `memset` used by mbedTLS). `GOT.mem.*` entries are zero-initialized, so extensions that take the address of an external global variable may not work correctly.
 
-### Snapshot Portability
+### Snapshot portability
 
 A snapshot taken with extensions can **only** be restored with the exact same extensions, in the exact same order, compiled from the exact same source with the exact same toolchain. The snapshot stores raw memory addresses and function table indices. If any of these change (e.g., because an extension was recompiled), the restored snapshot will be corrupted.
 
-### No Hot-Swapping
+### No hot-swapping
 
 Extensions are loaded once at `QuickJS.create()` time and cannot be added, removed, or replaced on a running VM.
 
-### Extensions Must Be Ordered Consistently
+### Extensions must be ordered consistently
 
 If you load extensions `[A, B]`, you must restore with `[A, B]` in the same order. The function table layout depends on loading order.
 
-## Snapshot Format (Version 2)
+## Snapshot format (version 2)
 
 Version 2 of the snapshot format adds extension metadata:
 

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -1,14 +1,14 @@
 # Native WASM Extensions
 
-quickjs-wasi supports loading native C extensions compiled as WebAssembly shared libraries. Extensions link directly against the QuickJS C API through WASM dynamic linking — they share the same linear memory, function table, and heap allocator as the main QuickJS module, so there is zero marshalling overhead when calling QuickJS APIs.
+quickjs-wasi supports loading native C extensions compiled as WebAssembly shared libraries. Extensions link directly against the QuickJS C API through WASM dynamic linking: they share the same linear memory, function table, and heap allocator as the main QuickJS module, so there is zero marshalling overhead when calling QuickJS APIs.
 
 This enables implementing Web API polyfills (URL, FormData, Blob, etc.) and other performance-critical functionality in C rather than JavaScript, while keeping them loadable at runtime as separate `.so` files.
 
-## Quick Start
+## Get started
 
 ### Using a Built-in Extension
 
-Each pre-built extension's compiled `.so` is exposed as a package sub-export. The caller is responsible for loading the bytes — quickjs-wasi never reads from disk or fetches over the network on your behalf:
+Each pre-built extension's compiled `.so` is exposed as a package sub-export. The caller is responsible for loading the bytes; quickjs-wasi never reads from disk or fetches over the network on your behalf:
 
 ```typescript
 import { readFile } from 'node:fs/promises';
@@ -120,24 +120,24 @@ vm.evalCode('hello()').consume(h => h.toString()); // "Hello from a native exten
 
 Extensions use the [WebAssembly dynamic linking convention](https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md). The main `quickjs.wasm` module is a statically-linked WASI reactor that exports:
 
-- **Memory** (`memory`) — the shared linear memory
-- **Function table** (`__indirect_function_table`) — shared across all modules
-- **Stack pointer** (`__stack_pointer`) — shared mutable global
-- **QuickJS C API** — 200+ functions (`JS_NewClass`, `JS_SetPropertyStr`, `JS_Eval`, etc.)
-- **libc** — `malloc`/`free`, string functions, math functions, formatting, etc.
-- **Heap allocator** — `malloc`, `free`, `calloc`, `realloc`
+- **Memory** (`memory`): the shared linear memory
+- **Function table** (`__indirect_function_table`): shared across all modules
+- **Stack pointer** (`__stack_pointer`): shared mutable global
+- **QuickJS C API**: 200+ functions (`JS_NewClass`, `JS_SetPropertyStr`, `JS_Eval`, etc.)
+- **libc**: `malloc`/`free`, string functions, math functions, formatting, etc.
+- **Heap allocator**: `malloc`, `free`, `calloc`, `realloc`
 
 Extensions are compiled as WASM shared libraries (`.so` files) with `-fPIC --shared`. They contain a `dylink.0` custom section that declares their memory and table requirements. When loaded, the extension loader:
 
 1. **Parses `dylink.0`** to determine how much memory and table space the extension needs
 2. **Allocates memory** for the extension's static data using `malloc` from the main module
 3. **Grows the function table** to accommodate the extension's function pointers
-4. **Resolves imports** — maps `env.*` imports to the main module's exports
+4. **Resolves imports**: maps `env.*` imports to the main module's exports
 5. **Instantiates** the extension WASM module with the shared memory and table
 6. **Applies data relocations** (`__wasm_apply_data_relocs`) and calls constructors (`__wasm_call_ctors`)
 7. **Calls the init function** (e.g., `qjs_ext_url_init(ctx, rt)`)
 
-Because all modules share the same linear memory, a `JSContext*` pointer in the extension points to the same struct that QuickJS is using — there is no serialization or copying when calling QuickJS APIs.
+Because all modules share the same linear memory, a `JSContext*` pointer in the extension points to the same struct that QuickJS is using, so there is no serialization or copying when calling QuickJS APIs.
 
 ### Extension Init Function
 
@@ -173,7 +173,7 @@ const char *qjs_ext_myext_versions(void) {
 }
 ```
 
-The naming convention follows `qjs_ext_<name>_versions`, matching the init function pattern (with `-` replaced by `_`). If the export is not found, the extension simply contributes no version entries to `vm.versions`.
+The naming convention follows `qjs_ext_<name>_versions`, matching the init function pattern (with `-` replaced by `_`). If the export is not found, the extension contributes no version entries to `vm.versions`.
 
 On the host side, version entries from all loaded extensions are merged into the `vm.versions` object alongside the always-present `quickjs-wasi` and `quickjs` entries:
 
@@ -206,15 +206,15 @@ console.log(vm.versions);
 
 Extensions are fully compatible with the snapshot/restore system. The snapshot includes:
 
-- **All linear memory** — this contains extension-allocated objects, class instances, prototypes, and the extension's static data
-- **Extension metadata** — name, `memoryBase`, `tableBase`, and init function name for each loaded extension
+- **All linear memory**: this contains extension-allocated objects, class instances, prototypes, and the extension's static data
+- **Extension metadata**: name, `memoryBase`, `tableBase`, and init function name for each loaded extension
 
 When restoring from a snapshot:
 
 1. **Memory is grown** to match the snapshot size
-2. **Extensions are re-instantiated** with the **exact same** `memoryBase` and `tableBase` values — this reconstructs the function table identically
-3. **Linear memory is overwritten** with the snapshot data — this restores all state, including extension objects
-4. **Init functions are NOT called** — the state is already in the memory
+2. **Extensions are re-instantiated** with the **exact same** `memoryBase` and `tableBase` values, which reconstructs the function table identically
+3. **Linear memory is overwritten** with the snapshot data, which restores all state, including extension objects
+4. **Init functions are NOT called**: the state is already in the memory
 
 This means:
 - Objects created by extensions before the snapshot still work after restore
@@ -234,7 +234,7 @@ vm1.evalCode(`
 const bytes = QuickJS.serializeSnapshot(vm1.snapshot());
 vm1.dispose();
 
-// Restore — must provide same extensions in same order
+// Restore: must provide same extensions in same order
 const vm2 = await QuickJS.restore(QuickJS.deserializeSnapshot(bytes), {
   extensions: [{ name: 'url', wasm: urlExtBytes }],
 });
@@ -261,7 +261,7 @@ Extensions can call any function exported by the main module. This includes:
 - Functions: `JS_NewCFunction`, `JS_NewCFunction2`, `JS_NewCFunctionData`, `JS_Call`
 - Errors: `JS_ThrowTypeError`, `JS_ThrowRangeError`, `JS_ThrowOutOfMemory`
 - Type checking: `JS_IsString`, `JS_IsObject`, `JS_IsArray`, `JS_IsFunction`, etc.
-- And many more — see [`quickjs.h`](https://github.com/quickjs-ng/quickjs/blob/master/quickjs.h) for the full API
+- And many more; see [`quickjs.h`](https://github.com/quickjs-ng/quickjs/blob/master/quickjs.h) for the full API
 
 **libc functions**:
 - Memory: `malloc`, `free`, `calloc`, `realloc`, `memcpy`, `memset`, `memmove`, `memcmp`, `memchr`
@@ -383,9 +383,9 @@ See each extension's README for full API documentation.
 
 Extensions that import `wasi_snapshot_preview1` functions (like the crypto extension importing `random_get`) receive WASI implementations from a three-layer merge:
 
-1. **Built-in defaults** (lowest priority) — the implementations in `wasi-shim.ts`
-2. **Extension-provided** — via `ExtensionDescriptor.wasi` factory
-3. **User overrides** (highest priority) — via `QuickJSOptions.wasi` factory
+1. **Built-in defaults** (lowest priority): the implementations in `wasi-shim.ts`
+2. **Extension-provided**: via `ExtensionDescriptor.wasi` factory
+3. **User overrides** (highest priority): via `QuickJSOptions.wasi` factory
 
 This means an extension can ship its own WASI implementations, and users can still override them:
 
@@ -428,21 +428,21 @@ The `dylink.0` section format and GOT conventions could change in a future wasi-
 
 ### Same Toolchain Requirement
 
-The main module and all extensions **must be compiled with the same wasi-sdk version**. If you upgrade wasi-sdk and rebuild `quickjs.wasm`, you must also rebuild all extensions. There is no versioning mechanism to detect mismatches — struct layouts, calling conventions, and symbol mangling could silently differ between toolchain versions.
+The main module and all extensions **must be compiled with the same wasi-sdk version**. If you upgrade wasi-sdk and rebuild `quickjs.wasm`, you must also rebuild all extensions. There is no versioning mechanism to detect mismatches: struct layouts, calling conventions, and symbol mangling could silently differ between toolchain versions.
 
 The current build uses **wasi-sdk 32** (clang 22.1.0).
 
 ### No LTO for Extensions
 
-The main module uses link-time optimization (`-flto`), but extensions cannot — LTO is incompatible with `-fPIC --shared` in wasi-sdk. Extension code will not be as aggressively optimized. For most extensions this is irrelevant, but compute-heavy extensions may notice a difference.
+The main module uses link-time optimization (`-flto`), but extensions cannot, because LTO is incompatible with `-fPIC --shared` in wasi-sdk. Extension code will not be as aggressively optimized. For most extensions this is irrelevant, but compute-heavy extensions may notice a difference.
 
 ### Limited GOT Resolution
 
-The loader resolves `GOT.func.*` entries by looking up functions in the main module's exports and adding them to the indirect function table. This allows extensions to call main-module functions via function pointers (e.g. `memset` used by mbedTLS). `GOT.mem.*` entries are zero-initialized — extensions that take the address of an external global variable may not work correctly.
+The loader resolves `GOT.func.*` entries by looking up functions in the main module's exports and adding them to the indirect function table. This allows extensions to call main-module functions via function pointers (e.g. `memset` used by mbedTLS). `GOT.mem.*` entries are zero-initialized, so extensions that take the address of an external global variable may not work correctly.
 
 ### Snapshot Portability
 
-A snapshot taken with extensions can **only** be restored with the exact same extensions, in the exact same order, compiled from the exact same source with the exact same toolchain. The snapshot stores raw memory addresses and function table indices — if any of these change (e.g., because an extension was recompiled), the restored snapshot will be corrupted.
+A snapshot taken with extensions can **only** be restored with the exact same extensions, in the exact same order, compiled from the exact same source with the exact same toolchain. The snapshot stores raw memory addresses and function table indices. If any of these change (e.g., because an extension was recompiled), the restored snapshot will be corrupted.
 
 ### No Hot-Swapping
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ OPT ?= -Oz
 # hard-failing.
 WASM_OPT ?= $(shell if [ -x node_modules/.bin/wasm-opt ]; then echo node_modules/.bin/wasm-opt; else echo wasm-opt; fi)
 
-# $(call wasm_opt,<file>) — optimize <file> in place.
+# $(call wasm_opt,<file>): optimize <file> in place.
 define wasm_opt
 	@if command -v $(WASM_OPT) >/dev/null 2>&1; then \
 		before=$$(wc -c < $(1)); \
@@ -57,7 +57,7 @@ endef
 # Compiler flags
 #
 # BUILDING_QJS_SHARED: since quickjs-ng 0.16 (commit 66adc82), JS_EXTERN only
-# carries default visibility when this is defined — without it, -fvisibility=hidden
+# carries default visibility when this is defined. Without it, -fvisibility=hidden
 # hides the JS_* API from the dynamic symbol table and extension .so files can no
 # longer resolve them at runtime through -Wl,--export-dynamic.
 CFLAGS = \
@@ -216,7 +216,7 @@ EXT_URL_OBJS = \
 EXT_URL_SO = $(EXT_URL_DIR)/url.so
 
 # Extensions: Encoding (TextEncoder / TextDecoder)
-# Pure C extension — no C++ dependencies needed.
+# Pure C extension; no C++ dependencies needed.
 EXT_ENC_DIR = extensions/encoding
 EXT_ENC_SO = $(EXT_ENC_DIR)/encoding.so
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install quickjs-wasi
 
 ## Usage
 
-### Loading the WASM Binary
+### Loading the WASM binary
 
 The caller is responsible for providing the WASM bytes (or a pre-compiled `WebAssembly.Module`): quickjs-wasi does no implicit filesystem or network I/O. The package ships the binary at the `quickjs-wasi/quickjs.wasm` subpath, which can be resolved by your environment's preferred mechanism.
 
@@ -40,7 +40,7 @@ const wasmModule = await WebAssembly.compileStreaming(fetch(wasmUrl));
 
 Compiling a `WebAssembly.Module` once and reusing it across many VMs is highly recommended, since instantiation from a compiled module is much faster than re-compiling bytes for each call to `QuickJS.create()`.
 
-### Basic Evaluation
+### Basic evaluation
 
 Both `QuickJS` and `JSValueHandle` implement `Symbol.dispose`, so you can use `using` declarations for automatic cleanup:
 
@@ -56,7 +56,7 @@ import { QuickJS } from 'quickjs-wasi';
 } // vm and result are automatically disposed here
 ```
 
-### Working with Values
+### Working with values
 
 ```typescript
 using vm = await QuickJS.create(wasmBytes);
@@ -81,7 +81,7 @@ const dumped = vm.dump(handle); // { x: 1, y: [2, 3] }
 const value = vm.evalCode('1 + 2').consume(h => h.toNumber()); // 3
 ```
 
-### Host Functions
+### Host functions
 
 Register JavaScript functions backed by host (Node.js) callbacks:
 
@@ -100,7 +100,7 @@ using result = vm.evalCode('add(3, 4)');
 console.log(result.toNumber()); // 7
 ```
 
-### Promises and Async Host Functions
+### Promises and async host functions
 
 Bridge async host operations into the QuickJS sandbox:
 
@@ -131,7 +131,7 @@ using vm = await QuickJS.create(wasmBytes);
 }
 ```
 
-### ES Modules
+### ES modules
 
 Evaluate code as an ES module with `EvalFlags.TYPE_MODULE`. Module evaluation
 returns a handle to a Promise that resolves to the module's namespace object
@@ -187,7 +187,7 @@ if ('value' in result) {
 }
 ```
 
-#### Async Module Loading
+#### Async module loading
 
 The `load` and `normalize` callbacks are **synchronous**: the engine calls
 them from inside the WASM call stack, which cannot be suspended to await a
@@ -238,7 +238,7 @@ const result = await vm.resolvePromise(promise);
 Alternatively, pre-fetch all module sources up front and serve them from the
 cache directly.
 
-### Error Handling
+### Error handling
 
 ```typescript
 using vm = await QuickJS.create(wasmBytes);
@@ -259,7 +259,7 @@ try {
 }
 ```
 
-### WASI Overrides
+### WASI overrides
 
 The `wasi` option lets you override any `wasi_snapshot_preview1` host function. It's a factory that receives the WASM linear memory and returns an object of override functions. Overrides apply to both the main module and all loaded extensions.
 
@@ -317,7 +317,7 @@ currentTime += 1000n; // advance 1 second
 vm.evalCode('Date.now()').consume(h => h.toNumber()); // 1700000001000
 ```
 
-### Memory Limits
+### Memory limits
 
 Restrict how much memory the QuickJS runtime can allocate. When exceeded, allocations fail and surface as JS exceptions:
 
@@ -338,7 +338,7 @@ vm.evalCode(`
 
 The limit is re-applied after `QuickJS.restore()`, so you can use a different limit for restored VMs than the original.
 
-### Interrupt Handler
+### Interrupt handler
 
 Prevent infinite loops and enforce execution timeouts:
 
@@ -365,7 +365,7 @@ vm.evalCode('1 + 2').consume(h => h.toNumber()); // 3
 
 The handler is called approximately once per JS bytecode instruction, so it should be fast. When it returns `true`, the current execution is interrupted and throws a `JSException`. The VM remains usable after an interrupt.
 
-### Timezone Offset
+### Timezone offset
 
 By default, `Date` inside the sandbox mirrors the host environment's timezone. You can override this with a fixed offset or a dynamic callback:
 
@@ -403,7 +403,7 @@ The `timezoneOffset` option accepts:
 - **A number**: fixed UTC offset in minutes using the `getTimezoneOffset()` sign convention (positive values are west of UTC, e.g. `480` for UTC-8).
 - **A callback `(timeSecs: number) => number`**: called with seconds since epoch, must return the offset in minutes. Useful for custom timezone logic. The callback is invoked whenever QuickJS needs to convert between UTC and local time (e.g. `getHours()`, `toString()`, `new Date(year, month, ...)`, `getTimezoneOffset()`), so it may be called multiple times per Date operation.
 
-### Snapshot and Restore
+### Snapshot and restore
 
 The key differentiator: snapshot the entire VM state and restore it later.
 
@@ -456,7 +456,7 @@ const restored = QuickJS.deserializeSnapshot(loaded);
 }
 ```
 
-### Host Callbacks After Restore
+### Host callbacks after restore
 
 Host functions registered with `newFunction()` are keyed by their name, which gets baked into the snapshot. After restoring, re-register the callbacks by name:
 
@@ -487,9 +487,9 @@ let snapshot: Snapshot;
 
 Note: each call to `newFunction()` must use a unique name. Attempting to register two host functions with the same name will throw an error.
 
-### Native WASM Extensions
+### Native WASM extensions
 
-Load C-based extensions compiled as WASM shared libraries. Extensions link directly against the QuickJS C API with zero marshalling overhead: they share the same linear memory and can register custom classes, prototypes, and globals.
+Load C-based extensions compiled as WASM shared libraries. Extensions link directly against the QuickJS C API with zero marshaling overhead: they share the same linear memory and can register custom classes, prototypes, and globals.
 
 The package ships five pre-built extensions, each available as a subpath export. As with the main `quickjs.wasm` binary, the caller is responsible for loading the bytes:
 
@@ -544,9 +544,9 @@ using vm2 = await QuickJS.restore(snapshot, {
 
 See [EXTENSIONS.md](./EXTENSIONS.md) for how to build your own extensions, how dynamic linking works, and known limitations.
 
-## API Reference
+## API reference
 
-### `QuickJS` (VM Instance)
+### `QuickJS` (VM instance)
 
 | Method | Description |
 |--------|-------------|
@@ -599,7 +599,7 @@ See [EXTENSIONS.md](./EXTENSIONS.md) for how to build your own extensions, how d
 | `initFn?` | Init function name (default: `qjs_ext_${name}_init`) |
 | `wasi?` | Extension-provided WASI overrides: `(memory) => ({...})`. Layered between built-in defaults and user overrides |
 
-### Cached Properties
+### Cached properties
 
 These are singleton handles. Do **not** dispose them:
 
@@ -696,7 +696,7 @@ lifetime is managed elsewhere.
 | `deferred.resolve(handle)` | Resolve the promise with a QuickJS value |
 | `deferred.reject(handle)` | Reject the promise with a QuickJS value |
 
-### Data Marshalling
+### Data marshaling
 
 `dump()` and `hostToHandle()` automatically convert values between the host and the QuickJS VM. The following types are supported:
 
@@ -727,13 +727,13 @@ lifetime is managed elsewhere.
 - Binary data is always **copied** between host and WASM memory; there is no zero-copy view API
 - `dump()` for typed arrays determines the host constructor from bytes-per-element (1 → `Uint8Array`, 2 → `Uint16Array`, 4 → `Uint32Array`, 8 → `Float64Array`)
 
-## How It Works
+## How it works
 
-### The Core Insight
+### The core insight
 
 WebAssembly linear memory is a flat byte array. Everything QuickJS allocates (the runtime struct, all contexts, all JS objects, the GC heap, the atom table, the promise job queue, pending promises) lives in this linear memory. There are no external pointers, file handles, or OS resources. When you copy the memory wholesale to a new WASM instance, all internal pointer relationships are preserved because they reference the same linear address space.
 
-### One VM = One WASM Instance
+### One VM = one WASM instance
 
 Unlike quickjs-emscripten which has a two-level model (`QuickJSWASMModule` → `QuickJSContext`), quickjs-wasm uses a simpler one-level model: each `QuickJS.create()` call instantiates its own WASM module with its own linear memory, runtime, and context. This gives stronger isolation (no shared memory between VMs) and makes snapshotting clean: one instance, one context, one snapshot.
 
@@ -759,7 +759,7 @@ Host (Node.js / Deno / Bun / Browser)
            +-- Snapshot support (get/set runtime and context pointers)
 ```
 
-### Host Callback Mechanism
+### Host callback mechanism
 
 When `vm.newFunction(name, fn)` is called, a QuickJS C function is created via `JS_NewCFunctionData2` with the function name stored as a JS string in `func_data[0]`. When QuickJS code calls the function, the C trampoline extracts the name and calls the imported `host_call(name_ptr, name_len, this_ptr, argc, argv_ptr)` function, which dispatches to the registered host callback by name.
 
@@ -773,7 +773,7 @@ This design survives snapshot/restore: the name string is stored in QuickJS's he
 - Node.js >= 22
 - pnpm
 
-### Building Locally
+### Building locally
 
 ```sh
 # Clone with submodules
@@ -794,9 +794,9 @@ pnpm run build
 pnpm test
 ```
 
-## Technical Details
+## Technical details
 
-### WASM Binary
+### WASM binary
 
 - Built from [quickjs-ng](https://github.com/quickjs-ng/quickjs) (MIT license)
 - Compiled with wasi-sdk targeting `wasm32-wasip1` in reactor mode
@@ -804,7 +804,7 @@ pnpm test
 - 7 WASM imports: 6 WASI functions + 1 `env.host_call` for host callbacks
 - Exports `memory` and `__stack_pointer` for snapshot support
 
-### What Gets Snapshotted
+### What gets snapshotted
 
 The snapshot captures the entire WASM linear memory, which contains:
 
@@ -819,16 +819,16 @@ The snapshot captures the entire WASM linear memory, which contains:
 
 Plus the `__stack_pointer` WASM global (a single i32).
 
-### Limitations and Future Work
+### Limitations and future work
 
 - **Snapshot size**: Snapshots capture the entire WASM linear memory (~256 KB baseline, grows with heap). Use `serializeSnapshot()` to get a binary buffer, then apply your own compression (gzip/zstd). The memory compresses well due to its large zero regions.
 - **Stack size limit**: QuickJS-ng disables `JS_SetMaxStackSize` on WASI, so deep recursion causes a WASM trap (not a catchable exception).
-- **ES Modules**: Supported via `EvalFlags.TYPE_MODULE` and the `moduleLoader` option (see [ES Modules](#es-modules)). Dynamic `import()` resolves through the same loader.
+- **ES modules**: Supported via `EvalFlags.TYPE_MODULE` and the `moduleLoader` option (see [ES modules](#es-modules)). Dynamic `import()` resolves through the same loader.
 - **Extension ABI**: Native WASM extensions use an experimental dynamic linking ABI that is [not yet stabilized](https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md). All extensions must be compiled with the same wasi-sdk version as the main module. See [EXTENSIONS.md](./EXTENSIONS.md) for details.
 
-### Browser Usage
+### Browser usage
 
-quickjs-wasi works in browsers: the TypeScript API uses only the standard `WebAssembly` API and the WASI shim is environment-agnostic. The package does no implicit I/O, so loading the WASM binary is up to you. See [Loading the WASM Binary](#loading-the-wasm-binary) above for `fetch()` and bundler-based examples.
+quickjs-wasi works in browsers: the TypeScript API uses only the standard `WebAssembly` API and the WASI shim is environment-agnostic. The package does no implicit I/O, so loading the WASM binary is up to you. See [Loading the WASM binary](#loading-the-wasm-binary) above for `fetch()` and bundler-based examples.
 
 ```typescript
 import { QuickJS } from 'quickjs-wasi';

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import wasmUrl from 'quickjs-wasi/quickjs.wasm?url';
 const wasmModule = await WebAssembly.compileStreaming(fetch(wasmUrl));
 ```
 
-Compiling a `WebAssembly.Module` once and reusing it across many VMs is highly recommended, since instantiation from a compiled module is much faster than re-compiling bytes for each call to `QuickJS.create()`.
+Compile a `WebAssembly.Module` once and reuse it across VMs: instantiation from a compiled module skips recompiling the ~620 KB binary on every `QuickJS.create()` call.
 
 ### Basic evaluation
 
@@ -261,7 +261,7 @@ try {
 
 ### WASI overrides
 
-The `wasi` option lets you override any `wasi_snapshot_preview1` host function. It's a factory that receives the WASM linear memory and returns an object of override functions. Overrides apply to both the main module and all loaded extensions.
+The `wasi` option lets you override any WebAssembly System Interface (WASI) `wasi_snapshot_preview1` host function. It's a factory that receives the WASM linear memory and returns an object of override functions. Overrides apply to both the main module and all loaded extensions.
 
 This is useful for deterministic execution: QuickJS uses a [xorshift64*](https://en.wikipedia.org/wiki/Xorshift) PRNG that is seeded once from the clock value during context creation. Override `clock_time_get` to control both `Date.now()` and the `Math.random()` seed:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install quickjs-wasi
 
 ### Loading the WASM Binary
 
-The caller is responsible for providing the WASM bytes (or a pre-compiled `WebAssembly.Module`) — quickjs-wasi does no implicit filesystem or network I/O. The package ships the binary at the `quickjs-wasi/quickjs.wasm` subpath, which can be resolved by your environment's preferred mechanism.
+The caller is responsible for providing the WASM bytes (or a pre-compiled `WebAssembly.Module`): quickjs-wasi does no implicit filesystem or network I/O. The package ships the binary at the `quickjs-wasi/quickjs.wasm` subpath, which can be resolved by your environment's preferred mechanism.
 
 Node.js (read from disk):
 
@@ -38,7 +38,7 @@ import wasmUrl from 'quickjs-wasi/quickjs.wasm?url';
 const wasmModule = await WebAssembly.compileStreaming(fetch(wasmUrl));
 ```
 
-Compiling a `WebAssembly.Module` once and reusing it across many VMs is highly recommended — instantiation from a compiled module is much faster than re-compiling bytes for each call to `QuickJS.create()`.
+Compiling a `WebAssembly.Module` once and reusing it across many VMs is highly recommended, since instantiation from a compiled module is much faster than re-compiling bytes for each call to `QuickJS.create()`.
 
 ### Basic Evaluation
 
@@ -50,7 +50,7 @@ import { QuickJS } from 'quickjs-wasi';
 {
   using vm = await QuickJS.create({ wasm: wasmBytes });
 
-  // Evaluate code — handles are auto-disposed with `using`
+  // Evaluate code. Handles are auto-disposed with `using`
   using result = vm.evalCode('1 + 2');
   console.log(result.toNumber()); // 3
 } // vm and result are automatically disposed here
@@ -61,7 +61,7 @@ import { QuickJS } from 'quickjs-wasi';
 ```typescript
 using vm = await QuickJS.create(wasmBytes);
 
-// Create values — `using` ensures they're disposed at end of scope
+// Create values. `using` ensures they're disposed at end of scope
 {
   using str = vm.newString('hello');
   using num = vm.newNumber(42);
@@ -189,7 +189,7 @@ if ('value' in result) {
 
 #### Async Module Loading
 
-The `load` and `normalize` callbacks are **synchronous** — the engine calls
+The `load` and `normalize` callbacks are **synchronous**: the engine calls
 them from inside the WASM call stack, which cannot be suspended to await a
 Promise (returning one throws a `TypeError`). To load module sources
 asynchronously (e.g. over `https://`), use the **fetch-and-retry** pattern:
@@ -263,7 +263,7 @@ try {
 
 The `wasi` option lets you override any `wasi_snapshot_preview1` host function. It's a factory that receives the WASM linear memory and returns an object of override functions. Overrides apply to both the main module and all loaded extensions.
 
-This is useful for deterministic execution — QuickJS uses a [xorshift64*](https://en.wikipedia.org/wiki/Xorshift) PRNG that is seeded once from the clock value during context creation. Override `clock_time_get` to control both `Date.now()` and the `Math.random()` seed:
+This is useful for deterministic execution: QuickJS uses a [xorshift64*](https://en.wikipedia.org/wiki/Xorshift) PRNG that is seeded once from the clock value during context creation. Override `clock_time_get` to control both `Date.now()` and the `Math.random()` seed:
 
 ```typescript
 const fixedClock = (memory: WebAssembly.Memory) => ({
@@ -347,7 +347,7 @@ const start = Date.now();
 using vm = await QuickJS.create({
   wasm: wasmBytes,
   interruptHandler: () => {
-    // Return true to interrupt — called periodically during JS execution
+    // Return true to interrupt. Called periodically during JS execution
     return Date.now() - start > 5000; // 5 second timeout
   },
 });
@@ -355,7 +355,7 @@ using vm = await QuickJS.create({
 try {
   vm.evalCode('while (true) {}');
 } catch (err) {
-  // JSException — interrupted
+  // JSException: interrupted
   err.dispose();
 }
 
@@ -399,13 +399,13 @@ using vm = await QuickJS.create({
 
 The `timezoneOffset` option accepts:
 
-- **`'host'`** (default) — mirrors the host's timezone, including DST transitions.
-- **A number** — fixed UTC offset in minutes using the `getTimezoneOffset()` sign convention (positive values are west of UTC, e.g. `480` for UTC-8).
-- **A callback `(timeSecs: number) => number`** — called with seconds since epoch, must return the offset in minutes. Useful for custom timezone logic. The callback is invoked whenever QuickJS needs to convert between UTC and local time (e.g. `getHours()`, `toString()`, `new Date(year, month, ...)`, `getTimezoneOffset()`), so it may be called multiple times per Date operation.
+- **`'host'`** (default): mirrors the host's timezone, including DST transitions.
+- **A number**: fixed UTC offset in minutes using the `getTimezoneOffset()` sign convention (positive values are west of UTC, e.g. `480` for UTC-8).
+- **A callback `(timeSecs: number) => number`**: called with seconds since epoch, must return the offset in minutes. Useful for custom timezone logic. The callback is invoked whenever QuickJS needs to convert between UTC and local time (e.g. `getHours()`, `toString()`, `new Date(year, month, ...)`, `getTimezoneOffset()`), so it may be called multiple times per Date operation.
 
 ### Snapshot and Restore
 
-The key differentiator — snapshot the entire VM state and restore it later:
+The key differentiator: snapshot the entire VM state and restore it later.
 
 ```typescript
 let snapshot: Snapshot;
@@ -444,7 +444,7 @@ const restored = QuickJS.deserializeSnapshot(loaded);
 {
   using vm = await QuickJS.restore(restored, wasmBytes);
 
-  // The pending promise still exists — resolve it
+  // The pending promise still exists; resolve it
   using resolve = vm.global.getProp('__resolve');
   using arg = vm.newNumber(42);
   vm.callFunction(resolve, vm.undefined, arg).dispose();
@@ -473,7 +473,7 @@ let snapshot: Snapshot;
 }
 
 {
-  // After restore — re-register by name
+  // After restore, re-register by name
   using vm = await QuickJS.restore(snapshot, wasmBytes);
   vm.registerHostCallback('hostAdd', (...args) => {
     return vm.newNumber(args[0].toNumber() + args[1].toNumber());
@@ -489,7 +489,7 @@ Note: each call to `newFunction()` must use a unique name. Attempting to registe
 
 ### Native WASM Extensions
 
-Load C-based extensions compiled as WASM shared libraries. Extensions link directly against the QuickJS C API with zero marshalling overhead — they share the same linear memory and can register custom classes, prototypes, and globals.
+Load C-based extensions compiled as WASM shared libraries. Extensions link directly against the QuickJS C API with zero marshalling overhead: they share the same linear memory and can register custom classes, prototypes, and globals.
 
 The package ships five pre-built extensions, each available as a subpath export. As with the main `quickjs.wasm` binary, the caller is responsible for loading the bytes:
 
@@ -530,7 +530,7 @@ import urlSoUrl from 'quickjs-wasi/url.so?url';
 const urlExtBytes = await fetch(urlSoUrl).then((r) => r.arrayBuffer());
 ```
 
-Extensions survive snapshot/restore — provide the same extensions when restoring:
+Extensions survive snapshot/restore. Provide the same extensions when restoring:
 
 ```typescript
 const snapshot = vm.snapshot();
@@ -577,7 +577,7 @@ See [EXTENSIONS.md](./EXTENSIONS.md) for how to build your own extensions, how d
 | `vm.snapshot()` | Capture the entire VM state (including extension metadata) |
 | `vm.registerHostCallback(name, fn)` | Re-register a host callback by name after restore |
 | `vm.dispose()` | Free the VM |
-| `vm[Symbol.dispose]()` | Same as `dispose()` — enables `using vm = ...` |
+| `vm[Symbol.dispose]()` | Same as `dispose()`, enables `using vm = ...` |
 
 ### `QuickJSOptions`
 
@@ -587,7 +587,7 @@ See [EXTENSIONS.md](./EXTENSIONS.md) for how to build your own extensions, how d
 | `wasi` | WASI override factory: `(memory) => ({ random_get, clock_time_get, ... })`. Applies to main module and all extensions |
 | `memoryLimit` | Maximum memory the QuickJS runtime can allocate (bytes) |
 | `interruptHandler` | Callback to interrupt execution (return `true` to stop) |
-| `extensions` | Array of `ExtensionDescriptor` objects — native WASM extensions to load |
+| `extensions` | Array of `ExtensionDescriptor` objects (native WASM extensions to load) |
 | `timezoneOffset` | Timezone for `Date` inside the VM: `'host'` (default), fixed offset in minutes, or `(timeSecs) => minutes` callback |
 
 ### `ExtensionDescriptor`
@@ -601,7 +601,7 @@ See [EXTENSIONS.md](./EXTENSIONS.md) for how to build your own extensions, how d
 
 ### Cached Properties
 
-These are singleton handles — do **not** dispose them:
+These are singleton handles. Do **not** dispose them:
 
 | Property | Value |
 |----------|-------|
@@ -628,7 +628,7 @@ These are singleton handles — do **not** dispose them:
 | `handle.consume(fn)` | Call `fn(handle)`, then dispose, return result |
 | `handle.dup()` | Duplicate the handle (increment refcount) |
 | `handle.dispose()` | Free the handle |
-| `handle[Symbol.dispose]()` | Same as `dispose()` — enables `using handle = ...` |
+| `handle[Symbol.dispose]()` | Same as `dispose()`, enables `using handle = ...` |
 
 #### Trap-free introspection
 
@@ -638,11 +638,11 @@ to call on hostile or unknown values (e.g. when rendering an inspector UI,
 or implementing side-effect-free serialization).
 
 The brand checks, `classId`, and `getProxyTarget()`/`getProxyHandler()`
-never execute guest code on **any** value — no proxy traps, no getters, no
+never execute guest code on **any** value: no proxy traps, no getters, no
 `Symbol.hasInstance`. The two property-inspection helpers
 (`getOwnPropertyKeys()` and `getOwnPropertyDescriptor()`) never invoke
 getters and are guest-code free for ordinary objects, but on a Proxy they
-necessarily fire its `ownKeys`/`getOwnPropertyDescriptor` traps — check
+necessarily fire its `ownKeys`/`getOwnPropertyDescriptor` traps. Check
 `isProxy` first if that matters.
 
 | Method / Property | Description |
@@ -657,9 +657,9 @@ necessarily fire its `ownKeys`/`getOwnPropertyDescriptor` traps — check
 | `handle.getProxyHandler()` | The `[[ProxyHandler]]` of a Proxy, without firing traps |
 | `handle.getOwnPropertyKeys()` | All own keys (strings **and** symbols, incl. non-enumerable), à la `Reflect.ownKeys()` |
 | `handle.getOwnPropertyDescriptor(key)` | Own property descriptor **without invoking getters**; accessor properties yield `get`/`set` handles |
-| `handle.identity` | Numeric identity of the underlying heap value (`0` for non-heap values) — key a `Map` on this to deduplicate or detect cycles across handles |
+| `handle.identity` | Numeric identity of the underlying heap value (`0` for non-heap values). Key a `Map` on this to deduplicate or detect cycles across handles |
 | `handle.toBoolean()` | Extract as a `boolean`, applying JavaScript truthiness |
-| `vm.construct(ctor, ...args)` | Invoke a constructor with `new` — the counterpart to `callFunction` for building values in the VM from the host |
+| `vm.construct(ctor, ...args)` | Invoke a constructor with `new`, the counterpart to `callFunction` for building values in the VM from the host |
 
 Note that `handle.toString()` is **not** in this list: for values that are not
 already strings it performs a JavaScript string conversion, which executes
@@ -671,7 +671,7 @@ guest code. Guard with `handle.isString`, or call a captured intrinsic such as
 | Method / Property | Description |
 |-------------------|-------------|
 | `vm.withScope(fn)` | Run `fn`, disposing every handle created during it; use `scope.escape(handle)` to keep one. Scopes nest, and `escape()` transfers to the enclosing scope |
-| `vm.newEphemeralFunction(fn)` | Like `newFunction()`, but the host callback is unregistered when the handle is disposed — use for short-lived callbacks instead of inventing unique names |
+| `vm.newEphemeralFunction(fn)` | Like `newFunction()`, but the host callback is unregistered when the handle is disposed. Use for short-lived callbacks instead of inventing unique names |
 | `vm.unregisterHostCallback(name)` | Remove a callback registered by `newFunction()` / `registerHostCallback()` |
 | `handle.disposed` | Whether `dispose()` has been called |
 
@@ -683,7 +683,7 @@ const name = vm.withScope((scope) => {
 });
 ```
 
-Handle methods do not guard against use after disposal — reading from a
+Handle methods do not guard against use after disposal: reading from a
 disposed handle reads freed memory. Check `handle.disposed` when a handle's
 lifetime is managed elsewhere.
 
@@ -722,20 +722,20 @@ lifetime is managed elsewhere.
 - Global symbols (`Symbol.for()`) round-trip as real host `Symbol` values via `Symbol.for(description)`
 - Local (anonymous) symbols dump as `undefined` and throw if passed to `hostToHandle()`
 - Functions dump as `undefined` (cannot be meaningfully serialized)
-- Circular and shared references are preserved — `dump()` returns the same host object for the same QuickJS object pointer
+- Circular and shared references are preserved: `dump()` returns the same host object for the same QuickJS object pointer
 - Only own enumerable string properties are included when dumping objects
-- Binary data is always **copied** between host and WASM memory — there is no zero-copy view API
+- Binary data is always **copied** between host and WASM memory; there is no zero-copy view API
 - `dump()` for typed arrays determines the host constructor from bytes-per-element (1 → `Uint8Array`, 2 → `Uint16Array`, 4 → `Uint32Array`, 8 → `Float64Array`)
 
 ## How It Works
 
 ### The Core Insight
 
-WebAssembly linear memory is a flat byte array. Everything QuickJS allocates — the runtime struct, all contexts, all JS objects, the GC heap, the atom table, the promise job queue, pending promises — lives in this linear memory. There are no external pointers, file handles, or OS resources. When you copy the memory wholesale to a new WASM instance, all internal pointer relationships are preserved because they reference the same linear address space.
+WebAssembly linear memory is a flat byte array. Everything QuickJS allocates (the runtime struct, all contexts, all JS objects, the GC heap, the atom table, the promise job queue, pending promises) lives in this linear memory. There are no external pointers, file handles, or OS resources. When you copy the memory wholesale to a new WASM instance, all internal pointer relationships are preserved because they reference the same linear address space.
 
 ### One VM = One WASM Instance
 
-Unlike quickjs-emscripten which has a two-level model (`QuickJSWASMModule` → `QuickJSContext`), quickjs-wasm uses a simpler one-level model: each `QuickJS.create()` call instantiates its own WASM module with its own linear memory, runtime, and context. This gives stronger isolation (no shared memory between VMs) and makes snapshotting clean — one instance, one context, one snapshot.
+Unlike quickjs-emscripten which has a two-level model (`QuickJSWASMModule` → `QuickJSContext`), quickjs-wasm uses a simpler one-level model: each `QuickJS.create()` call instantiates its own WASM module with its own linear memory, runtime, and context. This gives stronger isolation (no shared memory between VMs) and makes snapshotting clean: one instance, one context, one snapshot.
 
 ### Architecture
 
@@ -769,7 +769,7 @@ This design survives snapshot/restore: the name string is stored in QuickJS's he
 
 ### Prerequisites
 
-- [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) (tested with v30) — set `WASI_SDK` env var or defaults to `/tmp/wasi-sdk`
+- [wasi-sdk](https://github.com/WebAssembly/wasi-sdk) (tested with v30). Set the `WASI_SDK` env var or it defaults to `/tmp/wasi-sdk`
 - Node.js >= 22
 - pnpm
 
@@ -780,7 +780,7 @@ This design survives snapshot/restore: the name string is stored in QuickJS's he
 git clone --recursive https://github.com/vercel-labs/quickjs-wasm.git
 cd quickjs-wasm
 
-# Install wasi-sdk (macOS arm64 — adjust URL for your platform)
+# Install wasi-sdk (macOS arm64; adjust URL for your platform)
 curl -sL "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-30/wasi-sdk-30.0-arm64-macos.tar.gz" \
   | tar xz -C /tmp --strip-components=1 --one-top-level=wasi-sdk
 
@@ -821,14 +821,14 @@ Plus the `__stack_pointer` WASM global (a single i32).
 
 ### Limitations and Future Work
 
-- **Snapshot size**: Snapshots capture the entire WASM linear memory (~256 KB baseline, grows with heap). Use `serializeSnapshot()` to get a binary buffer, then apply your own compression (gzip/zstd) — the memory compresses very well due to large zero regions.
+- **Snapshot size**: Snapshots capture the entire WASM linear memory (~256 KB baseline, grows with heap). Use `serializeSnapshot()` to get a binary buffer, then apply your own compression (gzip/zstd). The memory compresses well due to its large zero regions.
 - **Stack size limit**: QuickJS-ng disables `JS_SetMaxStackSize` on WASI, so deep recursion causes a WASM trap (not a catchable exception).
 - **ES Modules**: Supported via `EvalFlags.TYPE_MODULE` and the `moduleLoader` option (see [ES Modules](#es-modules)). Dynamic `import()` resolves through the same loader.
 - **Extension ABI**: Native WASM extensions use an experimental dynamic linking ABI that is [not yet stabilized](https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md). All extensions must be compiled with the same wasi-sdk version as the main module. See [EXTENSIONS.md](./EXTENSIONS.md) for details.
 
 ### Browser Usage
 
-quickjs-wasi works in browsers — the TypeScript API uses only the standard `WebAssembly` API and the WASI shim is environment-agnostic. The package does no implicit I/O, so loading the WASM binary is up to you. See [Loading the WASM Binary](#loading-the-wasm-binary) above for `fetch()` and bundler-based examples.
+quickjs-wasi works in browsers: the TypeScript API uses only the standard `WebAssembly` API and the WASI shim is environment-agnostic. The package does no implicit I/O, so loading the WASM binary is up to you. See [Loading the WASM Binary](#loading-the-wasm-binary) above for `fetch()` and bundler-based examples.
 
 ```typescript
 import { QuickJS } from 'quickjs-wasi';
@@ -837,7 +837,7 @@ import wasmUrl from 'quickjs-wasi/quickjs.wasm?url'; // Vite
 // Fetch the .wasm file and compile it once
 const wasmModule = await WebAssembly.compileStreaming(fetch(wasmUrl));
 
-// Create VMs from the pre-compiled module (fast — no re-compilation)
+// Create VMs from the pre-compiled module (fast, no re-compilation)
 using vm = await QuickJS.create({ wasm: wasmModule });
 ```
 

--- a/bench/encoding-benchmark.ts
+++ b/bench/encoding-benchmark.ts
@@ -169,7 +169,7 @@ async function main() {
 
     await bench.run();
 
-    console.log(`### ${name}${nativeOnly ? ' (native only — polyfill lacks encodeInto)' : ''}`);
+    console.log(`### ${name}${nativeOnly ? ' (native only; polyfill lacks encodeInto)' : ''}`);
     console.table(bench.table());
     console.log('');
   }

--- a/bench/opt-level-benchmark.ts
+++ b/bench/opt-level-benchmark.ts
@@ -2,7 +2,7 @@
  * -O2 vs -Oz A/B Benchmark
  *
  * Runs an identical set of CPU-bound JS workloads against two builds of our
- * own quickjs.wasm — one compiled with -O2 (speed) and one with -Oz (size) —
+ * own quickjs.wasm, one compiled with -O2 (speed) and one with -Oz (size),
  * to quantify the runtime cost of optimizing for size.
  *
  * Usage:

--- a/c/interface.c
+++ b/c/interface.c
@@ -91,7 +91,8 @@ static char *module_normalizer_trampoline(JSContext *ctx,
     char *result = host_module_normalize(module_base_name, module_name);
     if (!result) {
         /* The host may have already thrown a more specific error via
-           qjs_throw; only throw the generic error if it did not. */
+           qjs_throw; only throw the generic error if the host has not
+           thrown one already. */
         if (!JS_HasException(ctx))
             JS_ThrowReferenceError(ctx, "could not normalize module '%s'", module_name);
         return NULL;
@@ -122,7 +123,8 @@ static JSModuleDef *module_loader_trampoline(JSContext *ctx,
     char *source = host_module_load(module_name, &source_len);
     if (!source) {
         /* The host may have already thrown a more specific error via
-           qjs_throw; only throw the generic error if it did not. */
+           qjs_throw; only throw the generic error if the host has not
+           thrown one already. */
         if (!JS_HasException(ctx))
             JS_ThrowReferenceError(ctx, "could not load module '%s'", module_name);
         return NULL;

--- a/c/interface.c
+++ b/c/interface.c
@@ -91,7 +91,7 @@ static char *module_normalizer_trampoline(JSContext *ctx,
     char *result = host_module_normalize(module_base_name, module_name);
     if (!result) {
         /* The host may have already thrown a more specific error via
-           qjs_throw — only throw the generic error if it did not. */
+           qjs_throw; only throw the generic error if it did not. */
         if (!JS_HasException(ctx))
             JS_ThrowReferenceError(ctx, "could not normalize module '%s'", module_name);
         return NULL;
@@ -99,7 +99,7 @@ static char *module_normalizer_trampoline(JSContext *ctx,
     /* The host allocated with plain malloc, but QuickJS frees the returned
        name with js_free. Since quickjs-ng 0.16 the js_* allocator is an
        arena that stores a block header BEFORE each pointer, so handing it
-       a foreign pointer reads a garbage header and corrupts the heap —
+       a foreign pointer reads a garbage header and corrupts the heap;
        the two allocators can no longer be mixed. Copy into js_malloc'd
        memory and free the host buffer. */
     size_t len = strlen(result);
@@ -122,7 +122,7 @@ static JSModuleDef *module_loader_trampoline(JSContext *ctx,
     char *source = host_module_load(module_name, &source_len);
     if (!source) {
         /* The host may have already thrown a more specific error via
-           qjs_throw — only throw the generic error if it did not. */
+           qjs_throw; only throw the generic error if it did not. */
         if (!JS_HasException(ctx))
             JS_ThrowReferenceError(ctx, "could not load module '%s'", module_name);
         return NULL;
@@ -139,7 +139,7 @@ static JSModuleDef *module_loader_trampoline(JSContext *ctx,
 
     /* Extract the JSModuleDef from the compiled module function */
     JSModuleDef *m = (JSModuleDef *)JS_VALUE_GET_PTR(func_val);
-    /* Don't free func_val — the module is owned by the runtime */
+    /* Don't free func_val; the module is owned by the runtime */
     return m;
 }
 
@@ -262,7 +262,7 @@ const char *qjs_get_quickjs_version(void) {
 
 /* ---- Lifecycle ---- */
 
-/* Intrinsic bitmask flags — must match the TypeScript Intrinsics constants */
+/* Intrinsic bitmask flags; must match the TypeScript Intrinsics constants */
 #define QJS_INTRINSIC_DATE           (1 << 0)
 #define QJS_INTRINSIC_EVAL           (1 << 1)
 #define QJS_INTRINSIC_REGEXP         (1 << 2)
@@ -286,7 +286,7 @@ const char *qjs_get_quickjs_version(void) {
  * quickjs-ng's default `js__malloc_usable_size` (cutils.h) has no branch
  * for WASI and falls through to `return 0;`. The memory accounting adds
  * `usable_size(ptr) + MALLOC_OVERHEAD` per allocation, so with a zero
- * usable-size every allocation is recorded as overhead only — the actual
+ * usable-size every allocation is recorded as overhead only: the actual
  * bytes never count against `JS_SetMemoryLimit`, and `mallocSize` stays
  * near zero while real memory grows without bound (retained ArrayBuffers
  * reach GiB under an 8 MiB limit; see issue #30). The per-allocation
@@ -295,7 +295,7 @@ const char *qjs_get_quickjs_version(void) {
  * freely.
  *
  * wasi-libc's dlmalloc exports `malloc_usable_size`, so wiring it in
- * makes the accounting — and therefore `memoryLimit` — actually work.
+ * makes the accounting, and therefore `memoryLimit`, actually work.
  *
  * ---- Why the limit is enforced HERE and not via JS_SetMemoryLimit ----
  *
@@ -303,7 +303,7 @@ const char *qjs_get_quickjs_version(void) {
  * functions are called and refuses at exactly malloc_limit. When a guest
  * exhausts the limit with many small allocations, JS_ThrowOutOfMemory's
  * own allocation of the "out of memory" InternalError object is refused
- * too, and quickjs falls back to throwing a bare JS_NULL (issue #38) —
+ * too, and quickjs falls back to throwing a bare JS_NULL (issue #38):
  * in-guest `catch (e)` sees `null`, indistinguishable from `throw null`,
  * and the host gets a nameless, messageless exception.
  *
@@ -312,7 +312,7 @@ const char *qjs_get_quickjs_version(void) {
  * refused at a SOFT limit that sits QJS_OOM_HEADROOM below the
  * configured memoryLimit. Once a refusal happens, allocations may dip
  * into the reserved headroom (up to the full memoryLimit) so that the
- * InternalError object — and the guest/host code that inspects it — can
+ * InternalError object, and the guest/host code that inspects it, can
  * allocate. The reserve re-arms as soon as usage drops back below the
  * soft limit, and the configured memoryLimit remains a hard ceiling at
  * all times.
@@ -385,7 +385,7 @@ static void *qjs_wasi_realloc(void *opaque, void *ptr, size_t size) {
     size_t old_usable = ptr ? malloc_usable_size(ptr) : 0;
     /* Only consult the limiter when the block grows: a shrinking or
        same-size realloc releases (or keeps) memory and must never be
-       refused — usage can legitimately sit above the soft limit, e.g.
+       refused: usage can legitimately sit above the soft limit, e.g.
        right after qjs_set_memory_limit applies a tighter limit to a
        restored snapshot, and refusing would turn a memory-RELEASING
        operation into a spurious OOM. */
@@ -442,7 +442,7 @@ int qjs_init(void) {
  * intrinsics (same as qjs_init), or a bitmask of QJS_INTRINSIC_* flags
  * to create a minimal context.
  *
- * Note: BaseObjects is always included — it provides fundamental types
+ * Note: BaseObjects is always included; it provides fundamental types
  * (Object, Array, Number, String, etc.) without which nothing works.
  */
 __attribute__((export_name("qjs_init2")))
@@ -535,7 +535,7 @@ void qjs_set_memory_limit(size_t limit) {
        qjs_wasi_malloc): the engine-level check refuses at exactly the limit
        and leaves no headroom to construct the "out of memory" InternalError,
        so a bare `null` gets thrown instead (issue #38). Keep the engine
-       limit unlimited — and explicitly reset it, since a runtime restored
+       limit unlimited, and explicitly reset it, since a runtime restored
        from a snapshot may carry a persisted engine-level limit. */
     if (rt) JS_SetMemoryLimit(rt, 0);
 }
@@ -656,7 +656,7 @@ static JSValue resolve_to_func_data(JSContext *ctx, JSValueConst this_val,
  * the chained promise unchanged.
  *
  * The chaining uses JS_PromiseThen, the engine-level primitive that does
- * not consult Promise.prototype.then or Symbol.species — guest code that
+ * not consult Promise.prototype.then or Symbol.species, so guest code that
  * patches either cannot intercept or observe module namespace resolution.
  *
  * Consumes func_obj.
@@ -668,7 +668,7 @@ static JSValue eval_module_to_namespace(JSValue func_obj)
     /* Resolve module dependencies before evaluation. JS_Eval with
        COMPILE_ONLY already resolves the graph, and quickjs-ng's
        js_resolve_module early-returns for already-resolved modules, so
-       this is a no-op for that caller — but it is required for modules
+       this is a no-op for that caller, but it is required for modules
        deserialized from bytecode and keeps this helper self-contained. */
     if (JS_ResolveModule(ctx, func_obj) < 0) {
         JS_FreeValue(ctx, func_obj);
@@ -755,7 +755,7 @@ uint8_t *qjs_compile(const char *code, size_t code_len, const char *filename,
         memcpy(copy, buf, *out_len);
     } else {
         /* The host reports a NULL return via the pending QuickJS
-           exception — make sure there is one, or it would surface a
+           exception, so make sure there is one, or it would surface a
            stale/unset exception as the compile error. */
         JS_ThrowOutOfMemory(ctx);
         *out_len = 0;
@@ -861,13 +861,13 @@ int qjs_get_symbol_description(JSValue *val, JSValue **desc_out) {
     JS_FreeValue(ctx, global);
 
     if (!JS_IsUndefined(key_for_result)) {
-        /* Global symbol — keyFor returned the description string */
+        /* Global symbol: keyFor returned the description string */
         *desc_out = jsvalue_to_heap(key_for_result);
         return 1;
     }
     JS_FreeValue(ctx, key_for_result);
 
-    /* Local symbol — get the .description property */
+    /* Local symbol: get the .description property */
     JSValue desc = JS_GetPropertyStr(ctx, *val, "description");
     *desc_out = jsvalue_to_heap(desc);
     return 2;
@@ -892,7 +892,7 @@ const char *qjs_get_string(JSValue *val) {
  * Length-aware string conversion. Unlike qjs_get_string (JS_ToCString),
  * the result is NOT consumed via NUL-terminated reads: the byte length is
  * written to *plen, so embedded U+0000 code units survive. Lone
- * surrogates survive too — JS_ToCStringLen2 keeps unmatched surrogate
+ * surrogates survive too: JS_ToCStringLen2 keeps unmatched surrogate
  * code points, encoding them as 3-byte sequences (WTF-8). The host
  * decodes WTF-8 (standard UTF-8 plus surrogate-range sequences) to
  * recover the exact JS string. Free with qjs_free_cstring.
@@ -1045,11 +1045,11 @@ int qjs_get_class_id(JSValue *val) {
 }
 
 /*
- * Get the engine-level class name of a value as a JS string — e.g.
+ * Get the engine-level class name of a value as a JS string, e.g.
  * "Object", "Map", "Date", or the registered name of a class defined by
  * an extension. Like the brand checks above this is trap-free: it reads
  * the class table, so no Symbol.toStringTag lookups, constructor/name
- * property reads, proxy traps, or prototype-chain walks — and it cannot
+ * property reads, proxy traps, or prototype-chain walks, and it cannot
  * be spoofed by guest code. Note the engine registers the Proxy class
  * under the name "Object" (mirroring Object.prototype.toString); use
  * qjs_is_proxy to detect proxies.
@@ -1407,8 +1407,8 @@ JSValue *qjs_get_own_property_names_all(JSValue *obj) {
 }
 
 /*
- * Get ALL own property keys — strings AND symbols, including
- * non-enumerable — as a QuickJS Array (Reflect.ownKeys semantics).
+ * Get ALL own property keys (strings AND symbols, including
+ * non-enumerable) as a QuickJS Array (Reflect.ownKeys semantics).
  * String keys are returned as strings, symbol keys as symbols.
  * Returns a heap-allocated JSValue* pointing to the array, or
  * JS_EXCEPTION on failure.
@@ -1510,7 +1510,7 @@ int qjs_has_own_property(JSValue *obj, const char *name) {
 /*
  * qjs_has_own_property with a JSValue key instead of a C string. C-string
  * keys cannot express embedded NULs or lone surrogates; a JSValue key
- * (from qjs_new_string, which is length-aware) can — and also supports
+ * (from qjs_new_string, which is length-aware) can, and it also supports
  * symbols.
  */
 __attribute__((export_name("qjs_has_own_property_value")))
@@ -1554,7 +1554,7 @@ int qjs_property_is_enumerable(JSValue *obj, const char *name) {
     return ret; /* 0 = not found, -1 = error */
 }
 
-/* qjs_property_is_enumerable with a JSValue key — see
+/* qjs_property_is_enumerable with a JSValue key; see
  * qjs_has_own_property_value for why. */
 __attribute__((export_name("qjs_property_is_enumerable_value")))
 int qjs_property_is_enumerable_value(JSValue *obj, JSValue *key) {

--- a/examples/browser/main.tsx
+++ b/examples/browser/main.tsx
@@ -40,12 +40,12 @@ import '@/index.css';
 // ─── JSValue DataAccessor for react-inspector ───────────────────────────────
 
 /**
- * Guest values the inspector needs in order to render without executing
+ * Guest values the inspector needs to render without executing
  * guest code, captured once per VM.
  *
  * Rendering is the same problem shape as side-effect-free serialization: the
- * host inspects values the guest built, so any dynamic lookup —
- * `value.toString()`, `Symbol.iterator`, `.constructor.name` — dispatches
+ * host inspects values the guest built, so any dynamic lookup
+ * (`value.toString()`, `Symbol.iterator`, `.constructor.name`) dispatches
  * through guest-patchable prototypes and runs guest code *while drawing the
  * UI*. Capturing the methods up front and invoking them with an explicit
  * receiver keeps the display identical while making the lookup unpatchable.
@@ -115,7 +115,7 @@ function callToString(
 /**
  * Reads an own data property without invoking accessors or proxy traps.
  * Returns undefined for accessor properties, missing properties, and
- * proxies — callers decide what to display instead.
+ * proxies; callers decide what to display instead.
  */
 function readOwnData(
   handle: JSValueHandle,
@@ -153,7 +153,7 @@ const jsValueAccessor: DataAccessor = {
     // For objects, `handle.toString()` performs a JavaScript string
     // conversion, which dispatches through the guest's (patchable)
     // `toString`/`valueOf`. Use the captured intrinsic for the branded
-    // types the inspector renders this way — same output, unpatchable
+    // types the inspector renders this way: same output, unpatchable
     // lookup. Primitives convert without running any guest code.
     if (h.isObject) {
       const i = intrinsics(h.vm);
@@ -189,7 +189,7 @@ const jsValueAccessor: DataAccessor = {
     if (!h.isObject) return false;
     // Arrays are iterable but react-inspector handles them separately
     if (h.isArray) return false;
-    // Never probe a Proxy — it renders via [[Target]]/[[Handler]] instead
+    // Never probe a Proxy; it renders via [[Target]]/[[Handler]] instead
     if (h.isProxy) return false;
     // Genuine Map/Set: trust the brand, skip the probing call below
     if (h.isMap || h.isSet) return true;
@@ -199,7 +199,7 @@ const jsValueAccessor: DataAccessor = {
       method.dispose();
       return false;
     }
-    // Verify the iterator actually works — prototype objects have
+    // Verify the iterator actually works: prototype objects have
     // Symbol.iterator but throw when called without instance data.
     try {
       const iterator = h.vm.callFunction(method, h);
@@ -218,7 +218,7 @@ const jsValueAccessor: DataAccessor = {
     // Genuine Map/Set: iterate with the captured `forEach`, which reads the
     // internal entry list directly. The iterator protocol is never touched,
     // so a patched `Map.prototype[Symbol.iterator]` (or a patched
-    // `%MapIteratorPrototype%.next`) cannot run — or lie — while rendering.
+    // `%MapIteratorPrototype%.next`) cannot run, or lie, while rendering.
     if (h.isMap || h.isSet) {
       const i = intrinsics(h.vm);
       const entries: JSValueHandle[] = [];
@@ -333,7 +333,7 @@ const jsValueAccessor: DataAccessor = {
   getOwnPropertyDescriptor(value: unknown, prop: string): InspectedPropertyDescriptor | undefined {
     const h = value as JSValueHandle;
     if (h.isProxy) {
-      // The synthetic [[Target]]/[[Handler]] rows are plain data —
+      // The synthetic [[Target]]/[[Handler]] rows are plain data,
       // resolved through engine internals, no traps fired.
       if (prop === '[[Target]]') {
         return { value: h.getProxyTarget(), enumerable: true, configurable: false };
@@ -354,7 +354,7 @@ const jsValueAccessor: DataAccessor = {
     if (desc.get || desc.set) {
       // Accessor property. react-inspector keys off the truthiness of
       // `get`, so translate a guest `undefined` handle (truthy on the
-      // host!) to host undefined — and dispose the discarded handle.
+      // host!) to host undefined, and dispose the discarded handle.
       let get = desc.get;
       if (get?.isUndefined) {
         get.dispose();
@@ -395,7 +395,7 @@ const jsValueAccessor: DataAccessor = {
     if (h.isProxy) return 'Proxy';
 
     // Prefer the engine's class table: `className` is a trap-free,
-    // unspoofable read that labels every registered class — including the
+    // unspoofable read that labels every registered class, including the
     // typed arrays and extension-defined classes (URL, Headers,
     // TextEncoder, …) the previous hand-rolled brand ladder missed.
     // Generic names fall through: "Object"/"Function" so user classes get
@@ -412,7 +412,7 @@ const jsValueAccessor: DataAccessor = {
     }
 
     // Unbranded: take the constructor from the *prototype*, never from the
-    // value's own properties — `{ constructor: Map }` would otherwise be
+    // value's own properties: `{ constructor: Map }` would otherwise be
     // labelled "Map". This matches how DevTools derives the label, keeps
     // real class instances reporting their class, and both hops are
     // descriptor reads so neither invokes an accessor.
@@ -448,8 +448,8 @@ const jsValueAccessor: DataAccessor = {
   isObjectPrototype(value: unknown): boolean {
     const h = value as JSValueHandle;
     // Compare heap-value identity, not `.ptr`: `.ptr` is this handle's own
-    // JSValue box, so it differs for every handle — including two handles
-    // to `Object.prototype` — which silently disabled this guard.
+    // JSValue box, so it differs for every handle, including two handles
+    // to `Object.prototype`, which silently disabled this guard.
     return h.identity === intrinsics(h.vm).objectPrototypeIdentity;
   },
 };
@@ -622,7 +622,7 @@ declare class TextDecoder {
 
 // ─── atob / btoa + Uint8Array base64/hex type definitions ───────────────────
 //
-// These APIs are built-in to quickjs-ng v0.15.0+ — `atob`, `btoa` are global
+// These APIs are built-in to quickjs-ng v0.15.0+: `atob`, `btoa` are global
 // functions and the Uint8Array methods are part of the TypedArrays intrinsic.
 // We always surface their types in Monaco so users get autocomplete.
 
@@ -1372,7 +1372,7 @@ function App() {
         consoleObj.dispose();
       }
 
-      // Evaluate with ASYNC flag — result is always a Promise (supports top-level await)
+      // Evaluate with ASYNC flag: result is always a Promise (supports top-level await)
       try {
         const result = vm.evalCode(code, '<eval>', EvalFlags.ASYNC);
         vm.executePendingJobs();

--- a/examples/browser/src/index.css
+++ b/examples/browser/src/index.css
@@ -28,7 +28,7 @@
   font-display: swap;
 }
 
-/* Dark theme (always active — no light mode) */
+/* Dark theme (always active, no light mode) */
 @theme inline {
   --color-background: oklch(0.145 0 0);
   --color-foreground: oklch(0.985 0 0);

--- a/extensions/crypto/README.md
+++ b/extensions/crypto/README.md
@@ -18,7 +18,7 @@ const vm = await QuickJS.create({
 
 ### `crypto` global
 
-- `crypto.getRandomValues(typedArray)`: fill with cryptographically strong random values (max 65536 bytes)
+- `crypto.getRandomValues(typedArray)`: fill with cryptographically strong random values (max 65,536 bytes)
 - `crypto.randomUUID()`: generate a v4 UUID string
 - `crypto.subtle`: `SubtleCrypto` instance
 

--- a/extensions/crypto/README.md
+++ b/extensions/crypto/README.md
@@ -18,20 +18,20 @@ const vm = await QuickJS.create({
 
 ### `crypto` global
 
-- `crypto.getRandomValues(typedArray)` — fill with cryptographically strong random values (max 65536 bytes)
-- `crypto.randomUUID()` — generate a v4 UUID string
-- `crypto.subtle` — `SubtleCrypto` instance
+- `crypto.getRandomValues(typedArray)`: fill with cryptographically strong random values (max 65536 bytes)
+- `crypto.randomUUID()`: generate a v4 UUID string
+- `crypto.subtle`: `SubtleCrypto` instance
 
 ### `crypto.subtle` (SubtleCrypto)
 
-- `digest(algorithm, data)` — SHA-1, SHA-256, SHA-384, SHA-512
-- `generateKey(algorithm, extractable, keyUsages)` — HMAC, AES-CBC/CTR/GCM/KW, ECDSA (P-256/P-384/P-521), ECDH, Ed25519, X25519, RSA-OAEP/PKCS1v1.5/PSS
-- `importKey(format, keyData, algorithm, extractable, keyUsages)` — raw, pkcs8, spki formats
-- `exportKey(format, key)` — raw, pkcs8, spki formats
-- `sign(algorithm, key, data)` / `verify(algorithm, key, signature, data)` — HMAC, ECDSA, Ed25519, RSA
-- `encrypt(algorithm, key, data)` / `decrypt(algorithm, key, data)` — AES-GCM, AES-CBC, AES-CTR, RSA-OAEP
-- `deriveBits(algorithm, baseKey, length)` / `deriveKey(...)` — HKDF, PBKDF2, ECDH, X25519
-- `wrapKey(format, key, wrappingKey, algorithm)` / `unwrapKey(...)` — key wrapping via encrypt/decrypt
+- `digest(algorithm, data)`: SHA-1, SHA-256, SHA-384, SHA-512
+- `generateKey(algorithm, extractable, keyUsages)`: HMAC, AES-CBC/CTR/GCM/KW, ECDSA (P-256/P-384/P-521), ECDH, Ed25519, X25519, RSA-OAEP/PKCS1v1.5/PSS
+- `importKey(format, keyData, algorithm, extractable, keyUsages)`: raw, pkcs8, spki formats
+- `exportKey(format, key)`: raw, pkcs8, spki formats
+- `sign(algorithm, key, data)` / `verify(algorithm, key, signature, data)`: HMAC, ECDSA, Ed25519, RSA
+- `encrypt(algorithm, key, data)` / `decrypt(algorithm, key, data)`: AES-GCM, AES-CBC, AES-CTR, RSA-OAEP
+- `deriveBits(algorithm, baseKey, length)` / `deriveKey(...)`: HKDF, PBKDF2, ECDH, X25519
+- `wrapKey(format, key, wrappingKey, algorithm)` / `unwrapKey(...)`: key wrapping via encrypt/decrypt
 
 All SubtleCrypto methods return Promises.
 
@@ -42,7 +42,7 @@ All SubtleCrypto methods return Promises.
 
 ### Global Constructors
 
-`Crypto`, `SubtleCrypto`, and `CryptoKey` are exposed as global constructors per the Web Crypto spec. Calling them with `new` throws `TypeError("Illegal constructor")` — instances are only created internally by the crypto API.
+`Crypto`, `SubtleCrypto`, and `CryptoKey` are exposed as global constructors per the Web Crypto spec. Calling them with `new` throws `TypeError("Illegal constructor")`; instances are only created internally by the crypto API.
 
 ### Deterministic RNG
 

--- a/extensions/crypto/README.md
+++ b/extensions/crypto/README.md
@@ -1,4 +1,4 @@
-# Crypto Extension
+# Crypto extension
 
 A W3C Web Cryptography API implementation backed by [mbedTLS 4.0](https://github.com/Mbed-TLS/mbedtls) (PSA Crypto). Provides the `crypto` global with `SubtleCrypto` for cryptographic operations.
 
@@ -40,7 +40,7 @@ All SubtleCrypto methods return Promises.
 - Properties: `type` (`"secret"`, `"public"`, `"private"`), `extractable`, `algorithm` (frozen), `usages` (frozen)
 - `Symbol.toStringTag` = `"CryptoKey"`
 
-### Global Constructors
+### Global constructors
 
 `Crypto`, `SubtleCrypto`, and `CryptoKey` are exposed as global constructors per the Web Crypto spec. Calling them with `new` throws `TypeError("Illegal constructor")`; instances are only created internally by the crypto API.
 

--- a/extensions/crypto/crypto.c
+++ b/extensions/crypto/crypto.c
@@ -34,7 +34,7 @@
 #include "psa/crypto.h"
 
 /* ================================================================
- * WASI random_get — used as the external RNG for mbedTLS PSA
+ * WASI random_get, used as the external RNG for mbedTLS PSA
  * ================================================================ */
 
 /* WASI random_get syscall */
@@ -42,7 +42,7 @@ extern int __wasi_random_get(void *buf, size_t buf_len)
     __attribute__((__import_module__("wasi_snapshot_preview1"),
                    __import_name__("random_get")));
 
-/* mbedTLS external RNG callback — called by PSA internals */
+/* mbedTLS external RNG callback, called by PSA internals */
 psa_status_t mbedtls_psa_external_get_random(
     mbedtls_psa_external_random_context_t *context,
     uint8_t *output, size_t output_size, size_t *output_length)
@@ -426,7 +426,7 @@ static JSValue js_cryptokey_get_extractable(JSContext *ctx, JSValueConst this_va
     return JS_NewBool(ctx, kd->extractable);
 }
 
-/* CryptoKey.algorithm getter — returns a frozen algorithm object */
+/* CryptoKey.algorithm getter: returns a frozen algorithm object */
 static JSValue js_cryptokey_get_algorithm(JSContext *ctx, JSValueConst this_val) {
     CryptoKeyData *kd = (CryptoKeyData *)JS_GetOpaque(this_val, js_cryptokey_class_id);
     if (!kd) return JS_EXCEPTION;
@@ -2302,7 +2302,7 @@ static const JSCFunctionListEntry js_crypto_proto_funcs[] = {
     JS_CFUNC_DEF("randomUUID", 0, js_crypto_randomUUID),
 };
 
-/* Illegal constructor — throws TypeError matching browser behavior */
+/* Illegal constructor: throws TypeError matching browser behavior */
 static JSValue js_illegal_constructor(JSContext *ctx, JSValueConst new_target,
                                        int argc, JSValueConst *argv)
 {

--- a/extensions/crypto/mbedtls_config_wasm.h
+++ b/extensions/crypto/mbedtls_config_wasm.h
@@ -91,10 +91,10 @@
 
 /* Platform */
 #define MBEDTLS_PLATFORM_C
-/* Disable MBEDTLS_HAVE_TIME — WASI does not provide mbedtls_ms_time */
+/* Disable MBEDTLS_HAVE_TIME; WASI does not provide mbedtls_ms_time */
 /* #undef MBEDTLS_HAVE_TIME */
 
-/* Do NOT enable these — no filesystem, no network, no threads in WASM */
+/* Do NOT enable these: no filesystem, no network, no threads in WASM */
 /* #undef MBEDTLS_FS_IO */
 /* #undef MBEDTLS_NET_C */
 /* #undef MBEDTLS_TIMING_C */
@@ -104,7 +104,7 @@
 /* PSA Crypto core */
 #define MBEDTLS_PSA_CRYPTO_C
 
-/* Use external RNG — we provide mbedtls_psa_external_get_random() backed by
+/* Use external RNG: we provide mbedtls_psa_external_get_random() backed by
    WASI random_get / arc4random_buf. This avoids needing the entropy module,
    DRBG, and filesystem for seed storage. */
 #define MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
@@ -116,10 +116,10 @@
 /* Dynamic key store */
 #define MBEDTLS_PSA_KEY_STORE_DYNAMIC
 
-/* Assume exclusive buffers — safe in single-threaded WASM */
+/* Assume exclusive buffers; safe in single-threaded WASM */
 #define MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS
 
-/* Bignum, ASN.1, PK — needed for RSA/ECC key import/export (PKCS#8, SPKI, JWK) */
+/* Bignum, ASN.1, PK: needed for RSA/ECC key import/export (PKCS#8, SPKI, JWK) */
 #define MBEDTLS_ASN1_PARSE_C
 #define MBEDTLS_ASN1_WRITE_C
 #define MBEDTLS_PK_C
@@ -128,15 +128,15 @@
 #define MBEDTLS_PK_PARSE_EC_EXTENDED
 #define MBEDTLS_PK_PARSE_EC_COMPRESSED
 
-/* MD layer — needed by many modules */
+/* MD layer, needed by many modules */
 #define MBEDTLS_MD_C
 
-/* PEM parsing — for importing PEM-encoded keys */
+/* PEM parsing, for importing PEM-encoded keys */
 #define MBEDTLS_BASE64_C
 #define MBEDTLS_PEM_PARSE_C
 #define MBEDTLS_PEM_WRITE_C
 
-/* NIST key wrapping — AES-KW */
+/* NIST key wrapping (AES-KW) */
 #define MBEDTLS_NIST_KW_C
 
 /* Error strings (useful for debugging) */

--- a/extensions/encoding/README.md
+++ b/extensions/encoding/README.md
@@ -1,4 +1,4 @@
-# Encoding Extension
+# Encoding extension
 
 A WHATWG Encoding Standard compliant implementation of `TextEncoder` and `TextDecoder`. Supports UTF-8 encoding/decoding, and UTF-16LE/UTF-16BE decoding.
 

--- a/extensions/encoding/README.md
+++ b/extensions/encoding/README.md
@@ -18,17 +18,17 @@ const vm = await QuickJS.create({
 
 ### `TextEncoder`
 
-- Constructor: `new TextEncoder()` — always UTF-8 (per spec, encoding argument is ignored)
+- Constructor: `new TextEncoder()`, always UTF-8 (per spec, the encoding argument is ignored)
 - Property: `encoding` (always `"utf-8"`)
 - Methods: `encode(input)` returns `Uint8Array`, `encodeInto(source, destination)` returns `{ read, written }`
 - USVString semantics: lone surrogates are replaced with U+FFFD
 
 ### `TextDecoder`
 
-- Constructor: `new TextDecoder(label?, options?)` — supports UTF-8, UTF-16LE, UTF-16BE
+- Constructor: `new TextDecoder(label?, options?)` (supports UTF-8, UTF-16LE, UTF-16BE)
 - Options: `{ fatal: boolean, ignoreBOM: boolean }`
 - Properties: `encoding`, `fatal`, `ignoreBOM`
-- Method: `decode(input?, options?)` — supports streaming via `{ stream: true }`
+- Method: `decode(input?, options?)` (supports streaming via `{ stream: true }`)
 - Accepts `ArrayBuffer`, `TypedArray`, and `DataView` as input
 - BOM handling: UTF-8 BOM (EF BB BF), UTF-16LE BOM (FF FE), UTF-16BE BOM (FE FF) are stripped by default
 - Fatal mode: throws `TypeError` on invalid byte sequences

--- a/extensions/encoding/encoding.c
+++ b/extensions/encoding/encoding.c
@@ -347,7 +347,7 @@ static int32_t utf16_handler(UTF16DecoderState *st, int byte_or_eof) {
         if (is_lo_surr(code_unit)) {
             return (int32_t)surr_to_cp(lead, code_unit);
         }
-        /* Not a trail surrogate — error for the lead surrogate.
+        /* Not a trail surrogate: error for the lead surrogate.
            But we need to re-process this code_unit. We handle this
            by checking if it's a lead surrogate itself or a regular code unit. */
         if (is_hi_surr(code_unit)) {
@@ -859,7 +859,7 @@ static JSValue decode_utf16(JSContext *ctx, TextDecoderData *d,
                 }
                 have_cu = 1;
             } else if (pos < input_len) {
-                /* One byte left — save as lead_byte */
+                /* One byte left; save as lead_byte */
                 st->lead_byte = input[pos++];
                 break;
             } else {

--- a/extensions/headers/README.md
+++ b/extensions/headers/README.md
@@ -1,4 +1,4 @@
-# Headers Extension
+# Headers extension
 
 A WHATWG Fetch Standard compliant `Headers` class, providing HTTP header manipulation with case-insensitive name matching, value normalization, and sorted iteration.
 

--- a/extensions/headers/README.md
+++ b/extensions/headers/README.md
@@ -27,17 +27,17 @@ vm.evalCode(`
 - Constructor: `new Headers()`, `new Headers(init)`
   - `init` can be a `Headers` instance, an object of key/value pairs, or an array of `[name, value]` pairs
 - Methods:
-  - `append(name, value)` — append a header value (does not replace existing values)
-  - `delete(name)` — remove all values for a header name
-  - `get(name)` — get the combined value for a header name, or `null`
-  - `getSetCookie()` — returns an array of `Set-Cookie` header values (per spec, these are not combined)
-  - `has(name)` — check if a header exists
-  - `set(name, value)` — set a header, replacing any existing values
-  - `entries()` — returns an iterator of `[name, value]` pairs (sorted by name)
-  - `keys()` — returns an iterator of header names (sorted)
-  - `values()` — returns an iterator of header values (sorted by name)
-  - `forEach(callback [, thisArg])` — call a function for each header
-- `[Symbol.iterator]` — aliased to `entries()`, enabling `for...of` iteration
+  - `append(name, value)`: append a header value (does not replace existing values)
+  - `delete(name)`: remove all values for a header name
+  - `get(name)`: get the combined value for a header name, or `null`
+  - `getSetCookie()`: returns an array of `Set-Cookie` header values (per spec, these are not combined)
+  - `has(name)`: check if a header exists
+  - `set(name, value)`: set a header, replacing any existing values
+  - `entries()`: returns an iterator of `[name, value]` pairs (sorted by name)
+  - `keys()`: returns an iterator of header names (sorted)
+  - `values()`: returns an iterator of header values (sorted by name)
+  - `forEach(callback [, thisArg])`: call a function for each header
+- `[Symbol.iterator]`: aliased to `entries()`, enabling `for...of` iteration
 - Header names are case-insensitive and normalized to lowercase
 - Header values are trimmed of leading/trailing whitespace
 

--- a/extensions/headers/headers.c
+++ b/extensions/headers/headers.c
@@ -745,7 +745,7 @@ static SortedEntry *headers_sort_and_combine(JSContext *ctx, HeadersData *h,
     }
     for (size_t i = 0; i < h->count; i++) indices[i] = i;
 
-    /* Simple insertion sort (stable) for correctness with set-cookie ordering */
+    /* Insertion sort: stable, which set-cookie ordering requires */
     for (size_t i = 1; i < h->count; i++) {
         size_t key = indices[i];
         size_t j = i;

--- a/extensions/structured-clone/README.md
+++ b/extensions/structured-clone/README.md
@@ -1,4 +1,4 @@
-# Structured Clone Extension
+# Structured clone extension
 
 WHATWG HTML Standard compliant `structuredClone()` global function. Deep clones values following the Structured Clone algorithm with circular reference detection.
 

--- a/extensions/structured-clone/structured-clone.c
+++ b/extensions/structured-clone/structured-clone.c
@@ -65,7 +65,7 @@ static JSValue memory_find(CloneMemory *m, JSValue original) {
     void *ptr = JS_VALUE_GET_PTR(original);
     int tag = JS_VALUE_GET_TAG(original);
     for (int i = 0; i < m->count; i++) {
-        /* Compare by pointer and tag — same object identity */
+        /* Compare by pointer and tag: same object identity */
         if (JS_VALUE_GET_PTR(m->originals[i]) == ptr &&
             JS_VALUE_GET_TAG(m->originals[i]) == tag) {
             return m->clones[i];
@@ -563,7 +563,7 @@ static JSValue structured_clone_internal(JSContext *ctx, JSValue value, CloneMem
         return result;
     }
 
-    /* DataView — check before TypedArray since DataView is not a typed array */
+    /* DataView: check before TypedArray since DataView is not a typed array */
     if (JS_IsDataView(value)) {
         JSValue result = clone_dataview(ctx, value);
         if (!JS_IsException(result))
@@ -650,7 +650,7 @@ static JSValue structured_clone_internal(JSContext *ctx, JSValue value, CloneMem
         }
 
         if (clone_properties(ctx, result, value, mem) < 0) {
-            /* Don't free result — it's in the memory table and may be referenced */
+            /* Don't free result; it's in the memory table and may be referenced */
             return JS_EXCEPTION;
         }
 

--- a/extensions/structured-clone/structured-clone.c
+++ b/extensions/structured-clone/structured-clone.c
@@ -32,7 +32,7 @@
 
 /* ---- Circular reference tracking ---- */
 
-/* Simple dynamic array mapping original values to their clones.
+/* Dynamic array mapping original values to their clones.
    We store pairs of (original JSValue tag+ptr, clone JSValue).
    For cycle detection, we only care about object-type values. */
 

--- a/extensions/url/README.md
+++ b/extensions/url/README.md
@@ -1,4 +1,4 @@
-# URL Extension
+# URL extension
 
 A fully WHATWG URL Standard compliant implementation of `URL` and `URLSearchParams`, backed by the [ada-url](https://github.com/ada-url/ada) library (the same URL parser used by Node.js).
 

--- a/extensions/url/README.md
+++ b/extensions/url/README.md
@@ -27,7 +27,7 @@ vm.evalCode(`
 
 ### `URL`
 
-- Constructor: `new URL(url)`, `new URL(url, base)` — full base URL resolution support
+- Constructor: `new URL(url)`, `new URL(url, base)` (full base URL resolution support)
 - Getters/Setters: `href`, `protocol`, `username`, `password`, `host`, `hostname`, `port`, `pathname`, `search`, `hash`
 - Read-only: `origin`
 - Methods: `toString()`, `toJSON()`
@@ -36,10 +36,10 @@ vm.evalCode(`
 
 ### `URLSearchParams`
 
-- Constructor: `new URLSearchParams(init)` — parses query strings
+- Constructor: `new URLSearchParams(init)` (parses query strings)
 - Methods: `get()`, `getAll()`, `set()`, `has(key [, value])`, `delete(key [, value])`, `append()`, `sort()`, `toString()`, `forEach()`, `entries()`, `keys()`, `values()`
 - Property: `size`
-- `[Symbol.iterator]` — aliased to `entries()`, enabling `for...of` iteration
+- `[Symbol.iterator]`: aliased to `entries()`, enabling `for...of` iteration
 - Full WHATWG compliance: proper percent-encoding (spaces as `+`), key sorting
 
 ## Building

--- a/src/index.ts
+++ b/src/index.ts
@@ -2380,8 +2380,8 @@ export class QuickJS {
 /**
  * Whether a string-typed property key survives the NUL-terminated
  * C-string key APIs: embedded U+0000 truncates the key, and an UNPAIRED
- * surrogate cannot be UTF-8 encoded (paired surrogates, e.g. emoji,
- * encode fine). Keys that don't survive are routed through length-aware
+ * surrogate cannot be UTF-8 encoded (paired surrogates, such as those
+ * that encode emoji, are fine). Keys that don't survive are routed through length-aware
  * guest string values instead.
  */
 function stringKeyNeedsValuePath(key: string): boolean {
@@ -2396,7 +2396,7 @@ const LONE_SURROGATE_RE =
 
 /**
  * Encode a JS string to WTF-8 bytes. Well-formed strings (including
- * paired surrogates and emoji) take the native TextEncoder; strings with
+ * paired surrogates, such as emoji) take the native TextEncoder; strings with
  * LONE surrogates take a manual encode that writes each unpaired
  * surrogate as the 3-byte sequence quickjs's tolerant UTF-8 decoder
  * accepts; TextEncoder would replace them with U+FFFD, silently

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export const EvalFlags = {
   TYPE_MODULE: (1 << 0) as 1,
   /** Force strict mode. */
   STRICT: (1 << 3) as 8,
-  /** Compile only — do not execute. */
+  /** Compile only; do not execute. */
   COMPILE_ONLY: (1 << 5) as 32,
   /** Omit stack frames before this eval from Error backtraces. */
   BACKTRACE_BARRIER: (1 << 6) as 64,
@@ -112,7 +112,7 @@ export const CompileFlags = {
  * built-in JavaScript features are available in the VM.
  *
  * By default all intrinsics are enabled. Pass a bitmask of these flags
- * to create a minimal context — for example, omit `Intrinsics.EVAL` to
+ * to create a minimal context. For example, omit `Intrinsics.EVAL` to
  * prevent `eval()` usage, or omit `Intrinsics.PROXY` to disallow `Proxy`.
  *
  * `BaseObjects` (Object, Array, Number, String, Boolean, Error, etc.)
@@ -254,7 +254,7 @@ export interface QuickJSOptions {
    * Module loader for ES module `import` statements. When provided, the VM
    * can resolve and load modules.
    *
-   * Both callbacks are **synchronous** — they must return their result
+   * Both callbacks are **synchronous**: they must return their result
    * immediately. The engine calls them from inside the WASM call stack,
    * which cannot be suspended to await a Promise; returning a Promise
    * throws a `TypeError`.
@@ -263,7 +263,7 @@ export interface QuickJSOptions {
    * pre-fetch all module sources before evaluating and serve them from a
    * cache, or use the fetch-and-retry pattern: throw from `load` on a
    * cache miss, fetch the missing module on the host, and re-run
-   * `evalCode()` — already-loaded modules are cached by the runtime and
+   * `evalCode()`. Already-loaded modules are cached by the runtime and
    * are not re-requested. See the "ES Modules" section of the README.
    *
    * Errors thrown by either callback propagate to the guest as the
@@ -620,7 +620,7 @@ export class QuickJS {
     return this._versions;
   }
 
-  /** The global object. Cached — do not dispose. */
+  /** The global object. Cached; do not dispose. */
   get global(): JSValueHandle {
     if (!this._global) {
       this._global = new JSValueHandle(this, this.exports.qjs_get_global(), true);
@@ -628,7 +628,7 @@ export class QuickJS {
     return this._global;
   }
 
-  /** The undefined value. Cached — do not dispose. */
+  /** The undefined value. Cached; do not dispose. */
   get undefined(): JSValueHandle {
     if (!this._undefined) {
       this._undefined = new JSValueHandle(this, this.exports.qjs_get_undefined(), true);
@@ -636,7 +636,7 @@ export class QuickJS {
     return this._undefined;
   }
 
-  /** The null value. Cached — do not dispose. */
+  /** The null value. Cached; do not dispose. */
   get null(): JSValueHandle {
     if (!this._null) {
       this._null = new JSValueHandle(this, this.exports.qjs_get_null(), true);
@@ -644,7 +644,7 @@ export class QuickJS {
     return this._null;
   }
 
-  /** The true value. Cached — do not dispose. */
+  /** The true value. Cached; do not dispose. */
   get true(): JSValueHandle {
     if (!this._true) {
       this._true = new JSValueHandle(this, this.exports.qjs_get_true(), true);
@@ -652,7 +652,7 @@ export class QuickJS {
     return this._true;
   }
 
-  /** The false value. Cached — do not dispose. */
+  /** The false value. Cached; do not dispose. */
   get false(): JSValueHandle {
     if (!this._false) {
       this._false = new JSValueHandle(this, this.exports.qjs_get_false(), true);
@@ -717,7 +717,7 @@ export class QuickJS {
     const mainExports = instance.exports as Record<string, WebAssembly.ExportValue>;
     const exportedMemory = vm.exports.memory;
 
-    // Grow memory FIRST — extensions need the memory to be large enough
+    // Grow memory FIRST: extensions need the memory to be large enough
     // for their __memory_base offsets (which were allocated in the original
     // larger memory during create()).
     const currentPages = exportedMemory.buffer.byteLength / 65536;
@@ -744,7 +744,7 @@ export class QuickJS {
     }
 
     // Copy snapshot data into the module's own memory.
-    // This overwrites EVERYTHING — including the regions that extensions
+    // This overwrites EVERYTHING, including the regions that extensions
     // just initialized. That's correct because the snapshot already contains
     // the complete state including extension data.
     const dst = new Uint8Array(exportedMemory.buffer);
@@ -769,7 +769,7 @@ export class QuickJS {
    *
    * The format includes a versioned header followed by the raw memory.
    * Apply your own compression (gzip, zstd, etc.) on top for smaller
-   * storage — the memory compresses very well due to large zero regions.
+   * storage. The memory compresses well due to its large zero regions.
    *
    * Format (version 1):
    * ```
@@ -1010,7 +1010,7 @@ export class QuickJS {
 
     const hostPromiseRejection = (promisePtr: number, reasonPtr: number, isHandled: number): void => {
       if (!vm.unhandledRejectionHandler) {
-        // No handler registered — free the heap-allocated values
+        // No handler registered; free the heap-allocated values
         vm.exports.qjs_free_value(promisePtr);
         vm.exports.qjs_free_value(reasonPtr);
         return;
@@ -1035,8 +1035,8 @@ export class QuickJS {
     };
 
     // Guard against async (or otherwise non-string-returning) module loader
-    // callbacks. The WASM boundary is synchronous — a Promise cannot be
-    // awaited here — so fail with a clear error instead of coercing the
+    // callbacks. The WASM boundary is synchronous (a Promise cannot be
+    // awaited here), so fail with a clear error instead of coercing the
     // Promise to source text.
     const assertSyncString = (value: unknown, callbackName: string): string => {
       if (typeof value === 'string') return value;
@@ -1045,7 +1045,7 @@ export class QuickJS {
         : `type ${typeof value}`;
       throw new TypeError(
         `moduleLoader.${callbackName} must synchronously return a string (got ${got}). ` +
-        `Async module loading is not supported — pre-fetch module sources instead ` +
+        `Async module loading is not supported. Pre-fetch module sources instead ` +
         `(see the "ES Modules" section of the quickjs-wasi README).`
       );
     };
@@ -1054,7 +1054,7 @@ export class QuickJS {
     // Returns a malloc'd null-terminated string in WASM memory, or 0 (NULL) on error.
     const hostModuleNormalize = (baseNamePtr: number, namePtr: number): number => {
       if (!vm.moduleNormalizeHandler) {
-        // No normalize handler — return a copy of the specifier as-is
+        // No normalize handler; return a copy of the specifier as-is
         const name = vm.readCString(namePtr);
         return vm.writeString(name).ptr;
       }
@@ -1119,16 +1119,16 @@ export class QuickJS {
       // ("calling it after the handle is disposed throws, because the
       // callback is gone") and `unregisterHostCallback` ("any QuickJS
       // function still referencing the name will throw when called").
-      // Silently returning `undefined` here masked real bugs — e.g. a
+      // Silently returning `undefined` here masked real bugs, e.g. a
       // snapshot-restored VM calling a host function that was never
       // re-registered would corrupt results instead of failing loud.
       // Guest code can catch this like any other error.
       // A string (not a host Error object): newError copies an Error's
       // host .stack into the guest, which would leak host file paths into
       // guest-observable space and shadow any guest backtrace. This error
-      // is library-generated — there is no host stack worth preserving.
+      // is library-generated; there is no host stack worth preserving.
       const errHandle = this.newError(
-        `Host callback "${name}" is not registered — it was unregistered, ` +
+        `Host callback "${name}" is not registered: it was unregistered, ` +
           'its ephemeral function handle was disposed, or it was never ' +
           're-registered after a snapshot restore.'
       );
@@ -1140,7 +1140,7 @@ export class QuickJS {
     // `thisPtr` and the argv entries are OWNED BY THE C TRAMPOLINE, which
     // frees them after this call returns. Wrap them as borrowed handles:
     // dispose() is a no-op and they are exempt from `withScope()`
-    // tracking — a scope active around guest execution (e.g. a host
+    // tracking: a scope active around guest execution (e.g. a host
     // serializer driving a `forEach` visitor) must not free them at its
     // boundary, which would double-free the guest values and corrupt the
     // heap. Callbacks retain arguments past their invocation via `dup()`.
@@ -1173,7 +1173,7 @@ export class QuickJS {
   /** Write a JS string into WASM memory, returning the pointer. Caller must free. */
   private writeString(str: string): { ptr: number; len: number } {
     // WTF-8 (not plain TextEncoder): lone surrogates in the input must
-    // reach the guest intact — quickjs's decoder accepts the 3-byte
+    // reach the guest intact: quickjs's decoder accepts the 3-byte
     // surrogate sequences, so a JS string round-trips exactly.
     const encoded = encodeWtf8(str);
     const ptr = this.exports.wasm_malloc(encoded.length + 1);
@@ -1213,12 +1213,12 @@ export class QuickJS {
   /**
    * Evaluate JavaScript code and return the result as a handle.
    * If the code throws, a `JSException` (which extends `Error`) is thrown
-   * on the host side — matching standard JavaScript semantics.
+   * on the host side, matching standard JavaScript semantics.
    *
    * @param code - The JavaScript source code to evaluate.
    * @param filename - Optional filename for error stack traces (default `'<eval>'`).
    * @param flags - Optional bitwise OR of `EvalFlags.*` constants.
-   *   For example, pass `EvalFlags.ASYNC` to allow top-level `await` — the
+   *   For example, pass `EvalFlags.ASYNC` to allow top-level `await`; the
    *   returned handle will be a Promise that resolves to the completion value.
    *   With `EvalFlags.TYPE_MODULE` the returned handle is a Promise that
    *   resolves to the module's namespace object (its exports).
@@ -1257,7 +1257,7 @@ export class QuickJS {
     this.exports.wasm_free(fnStr.ptr);
     if (bufPtr === 0) {
       this.exports.wasm_free(outLenPtr);
-      // Compilation failed — throw the QuickJS exception
+      // Compilation failed; throw the QuickJS exception
       const exc = this.getException();
       throw new Error(`Compilation error: ${exc.toString()}`);
     }
@@ -1523,7 +1523,7 @@ export class QuickJS {
    * disposed when it returns, except those passed to `scope.escape()`.
    *
    * This is the bulk alternative to disposing handles individually, for code
-   * that creates many intermediates — walking a large value, for example:
+   * that creates many intermediates, such as walking a large value:
    *
    * ```ts
    * const name = vm.withScope((scope) => {
@@ -1572,14 +1572,14 @@ export class QuickJS {
    * Export a handle as a snapshot-portable token.
    *
    * A handle's heap box lives in the VM's linear memory, so a
-   * `snapshot()` taken while the handle is alive carries it — and a VM
+   * `snapshot()` taken while the handle is alive carries it, and a VM
    * restored from that snapshot has the identical box at the identical
    * offset. `importHandle(token)` on the restored VM (or on this VM)
    * re-materializes an owned handle for the same guest value without
    * evaluating any guest code.
    *
    * Contract:
-   * - the handle must stay undisposed until after `snapshot()` — its
+   * - the handle must stay undisposed until after `snapshot()`; its
    *   box (and the reference it holds) must be part of the memory image;
    * - the token is only meaningful to THIS VM and VMs restored from a
    *   snapshot of it taken while the handle was alive;
@@ -1587,12 +1587,12 @@ export class QuickJS {
    *   fresh box), so it can be called any number of times and each
    *   returned handle is independently owned and disposable. The
    *   exported box's own reference is intentionally never released on
-   *   restored VMs (one retained reference per VM image — reclaimed
+   *   restored VMs (one retained reference per VM image, reclaimed
    *   with the VM).
    *
    * The intended use is boot-time capture: snapshot a VM after capturing
    * references to pristine intrinsics but BEFORE evaluating untrusted or
-   * user code, then restore per task and import the captured handles —
+   * user code, then restore per task and import the captured handles,
    * guaranteeing the references predate anything user code patched,
    * without re-running capture code in the restored VM (where user-
    * patched globals could observe it). See vercel/workflow's host-side
@@ -1608,13 +1608,13 @@ export class QuickJS {
     }
     if (handle._isBorrowed) {
       // Host-callback this/argument handles wrap boxes OWNED BY THE C
-      // TRAMPOLINE, freed when the callback returns — a token minted
+      // TRAMPOLINE, freed when the callback returns; a token minted
       // from one would point at freed memory in every restored VM.
       // Callbacks that need to persist an argument must dup() it first
       // (the duplicate is an owned box) and export the duplicate.
       throw new Error(
         'exportHandle: cannot export a borrowed handle (host-callback ' +
-          'this/argument) — its box is freed when the callback returns. ' +
+          'this/argument); its box is freed when the callback returns. ' +
           'dup() it and export the duplicate.'
       );
     }
@@ -1622,7 +1622,7 @@ export class QuickJS {
   }
 
   /**
-   * Re-materialize a handle from a token produced by `exportHandle` —
+   * Re-materialize a handle from a token produced by `exportHandle`,
    * on this VM, or on a VM restored from a snapshot taken while the
    * exported handle was alive. Returns a NEW owned handle (the
    * underlying value's refcount is incremented); dispose it like any
@@ -1634,7 +1634,7 @@ export class QuickJS {
     // which dereferences it as a raw JSValue* inside the WASM instance.
     // A malformed token (0, negative, fractional, out of address range)
     // would otherwise read arbitrary memory. A well-formed but FORGED
-    // token remains undefined behavior — like any raw pointer, tokens
+    // token remains undefined behavior: like any raw pointer, tokens
     // are only meaningful under the exportHandle contract.
     if (
       !Number.isInteger(token) ||
@@ -1651,8 +1651,8 @@ export class QuickJS {
    * tied to the returned handle: disposing the handle unregisters the
    * callback.
    *
-   * Use this for short-lived callbacks — e.g. a visitor passed to
-   * `Map.prototype.forEach` — where the name is an implementation detail.
+   * Use this for short-lived callbacks (e.g. a visitor passed to
+   * `Map.prototype.forEach`) where the name is an implementation detail.
    * `newFunction()` keeps its callback registered for the lifetime of the VM
    * (by design, so that names can be re-registered after a snapshot is
    * restored), which makes it unsuitable for callbacks created in a loop.
@@ -1737,7 +1737,7 @@ export class QuickJS {
     vm._ownedHandles.add(resolveHandle);
     vm._ownedHandles.add(rejectHandle);
 
-    // Lazily-created settled promise — only attaches .then() handler when accessed
+    // Lazily-created settled promise: only attaches .then() handler when accessed
     let _settled: Promise<void> | null = null;
 
     return {
@@ -1801,7 +1801,7 @@ export class QuickJS {
       return Promise.resolve({ error: new JSValueHandle(this, this.exports.qjs_promise_result(promiseHandle.ptr)) });
     }
 
-    // Pending — attach a .then/.catch to get notified
+    // Pending: attach a .then/.catch to get notified
     return new Promise((hostResolve) => {
       const id = this.nextInternalId++;
       const fulfilledName = `__onFulfilled:${id}`;
@@ -1866,8 +1866,8 @@ export class QuickJS {
 
   /**
    * Invoke a QuickJS constructor with `new`, i.e. `new ctor(...args)`.
-   * If the constructor throws — including when `ctor` is not a constructor
-   * — a `JSException` is thrown on the host side.
+   * If the constructor throws (including when `ctor` is not a constructor),
+   * a `JSException` is thrown on the host side.
    *
    * This is the counterpart to `callFunction` for building values inside
    * the VM from the host, e.g. `new Date(iso)` on a constructor captured
@@ -2051,13 +2051,13 @@ export class QuickJS {
       const descPtr = view.getUint32(descOutPtr, true);
       e.wasm_free(descOutPtr);
       if (kind === 1) {
-        // Global symbol — reconstruct as Symbol.for(description)
+        // Global symbol: reconstruct as Symbol.for(description)
         const descHandle = new JSValueHandle(this, descPtr);
         const description = descHandle.toString();
         descHandle.dispose();
         return Symbol.for(description);
       } else if (kind === 2) {
-        // Local (anonymous) symbol — can't be reconstructed on host
+        // Local (anonymous) symbol: can't be reconstructed on host
         const descHandle = new JSValueHandle(this, descPtr);
         descHandle.dispose();
         return undefined;
@@ -2087,7 +2087,7 @@ export class QuickJS {
       }
     }
 
-    // Check for typed arrays (before regular array check — typed arrays are not Array.isArray)
+    // Check for typed arrays (before the regular array check; typed arrays are not Array.isArray)
     if (e.qjs_is_object(handle.ptr)) {
       const byteOffsetPtr = e.wasm_malloc(4);
       const byteLengthPtr = e.wasm_malloc(4);
@@ -2247,7 +2247,7 @@ export class QuickJS {
     }
 
     if (ArrayBuffer.isView(value)) {
-      // Other typed arrays — convert via Uint8Array view of the underlying buffer
+      // Other typed arrays: convert via Uint8Array view of the underlying buffer
       return this.newArrayBuffer(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
     }
 
@@ -2380,7 +2380,7 @@ export class QuickJS {
 /**
  * Whether a string-typed property key survives the NUL-terminated
  * C-string key APIs: embedded U+0000 truncates the key, and an UNPAIRED
- * surrogate cannot be UTF-8 encoded (paired surrogates — e.g. emoji —
+ * surrogate cannot be UTF-8 encoded (paired surrogates, e.g. emoji,
  * encode fine). Keys that don't survive are routed through length-aware
  * guest string values instead.
  */
@@ -2396,10 +2396,10 @@ const LONE_SURROGATE_RE =
 
 /**
  * Encode a JS string to WTF-8 bytes. Well-formed strings (including
- * paired surrogates — emoji) take the native TextEncoder; strings with
+ * paired surrogates and emoji) take the native TextEncoder; strings with
  * LONE surrogates take a manual encode that writes each unpaired
  * surrogate as the 3-byte sequence quickjs's tolerant UTF-8 decoder
- * accepts — TextEncoder would replace them with U+FFFD, silently
+ * accepts; TextEncoder would replace them with U+FFFD, silently
  * corrupting every host→guest string (sources, property keys,
  * newString values).
  */
@@ -2415,7 +2415,7 @@ function encodeWtf8(str: string): Uint8Array {
     } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < str.length) {
       const next = str.charCodeAt(i + 1);
       if (next >= 0xdc00 && next <= 0xdfff) {
-        // Well-formed pair — 4-byte UTF-8.
+        // Well-formed pair: 4-byte UTF-8.
         const cp = 0x10000 + ((code - 0xd800) << 10) + (next - 0xdc00);
         bytes.push(
           0xf0 | (cp >> 18),
@@ -2426,10 +2426,10 @@ function encodeWtf8(str: string): Uint8Array {
         i++;
         continue;
       }
-      // Lone high surrogate — 3-byte WTF-8.
+      // Lone high surrogate: 3-byte WTF-8.
       bytes.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
     } else {
-      // BMP char or lone (low / trailing high) surrogate — 3-byte form.
+      // BMP char or lone (low / trailing high) surrogate: 3-byte form.
       bytes.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
     }
   }
@@ -2442,8 +2442,8 @@ function encodeWtf8(str: string): Uint8Array {
  * is how quickjs's JS_ToCStringLen2 encodes lone surrogates ("keep
  * unmatched surrogate code points"). TextDecoder replaces those
  * sequences with U+FFFD, so they are detected first and the rare strings
- * containing them take a manual decode; everything else — the
- * overwhelming majority — uses the native decoder.
+ * containing them take a manual decode; everything else (the
+ * overwhelming majority) uses the native decoder.
  */
 function decodeWtf8(bytes: Uint8Array): string {
   let hasSurrogateSequence = false;
@@ -2466,7 +2466,7 @@ function decodeWtf8(bytes: Uint8Array): string {
       out += String.fromCharCode(((b0 & 0x1f) << 6) | (bytes[i + 1] & 0x3f));
       i += 2;
     } else if (b0 < 0xf0) {
-      // 3-byte sequence — may decode into the surrogate range, which is
+      // 3-byte sequence: may decode into the surrogate range, which is
       // exactly the WTF-8 extension: emit the code unit as-is.
       out += String.fromCharCode(
         ((b0 & 0x0f) << 12) | ((bytes[i + 1] & 0x3f) << 6) | (bytes[i + 2] & 0x3f)
@@ -2490,7 +2490,7 @@ function decodeWtf8(bytes: Uint8Array): string {
 /**
  * An exception thrown from QuickJS code. Extends `Error` so it works with
  * standard error handling (`instanceof Error`, `.message`, `.stack`), and
- * also exposes a `handle` property — a live `JSValueHandle` to the QuickJS
+ * also exposes a `handle` property, a live `JSValueHandle` to the QuickJS
  * exception value, allowing direct inspection of custom properties.
  *
  * The `handle` must be disposed when you're done with it (or use `using`).
@@ -2581,20 +2581,20 @@ export class JSValueHandle {
   private readonly singleton: boolean;
 
   /**
-   * When true, this handle wraps a `JSValue*` OWNED BY THE C CALLER — the
+   * When true, this handle wraps a `JSValue*` OWNED BY THE C CALLER: the
    * `this`/argument handles the host-call trampoline passes to a host
    * callback (`handleHostCall`). The C side frees those values after the
    * call returns, so `dispose()` is a no-op and the handle is never
    * registered with an active `withScope()` (either would double-free
    * the guest value and corrupt the heap). A callback that needs to
-   * retain an argument past its own invocation must `dup()` it — the
+   * retain an argument past its own invocation must `dup()` it; the
    * duplicate takes a fresh reference and behaves like any owned handle.
    * @internal
    */
   private readonly borrowed: boolean;
 
   /**
-   * Extra cleanup to run when this handle is disposed — used by
+   * Extra cleanup to run when this handle is disposed. Used by
    * `newEphemeralFunction()` to unregister its host callback.
    * @internal
    */
@@ -2613,7 +2613,7 @@ export class JSValueHandle {
   /**
    * Whether this handle wraps a C-owned pointer (host-callback
    * `this`/arguments). Borrowed handles must never be exported as
-   * snapshot tokens — the trampoline frees their boxes after the
+   * snapshot tokens: the trampoline frees their boxes after the
    * callback returns. @internal
    */
   get _isBorrowed(): boolean {
@@ -2624,7 +2624,7 @@ export class JSValueHandle {
    * Whether `dispose()` has been called on this handle.
    *
    * Note that handle methods do not currently guard against use after
-   * disposal — reading from a disposed handle reads freed memory. Check this
+   * disposal: reading from a disposed handle reads freed memory. Check this
    * when a handle's lifetime is managed elsewhere (e.g. by `withScope()`).
    */
   get disposed(): boolean {
@@ -2701,7 +2701,7 @@ export class JSValueHandle {
   }
 
   /**
-   * Whether this value is a Map (engine brand check — trap-free,
+   * Whether this value is a Map (engine brand check: trap-free,
    * spoof-proof, and unaffected by prototype/constructor mutation).
    * A Proxy wrapping a Map returns false.
    */
@@ -2710,7 +2710,7 @@ export class JSValueHandle {
   }
 
   /**
-   * Whether this value is a Set (engine brand check — trap-free,
+   * Whether this value is a Set (engine brand check: trap-free,
    * spoof-proof, and unaffected by prototype/constructor mutation).
    * A Proxy wrapping a Set returns false.
    */
@@ -2719,7 +2719,7 @@ export class JSValueHandle {
   }
 
   /**
-   * Whether this value is a Date (engine brand check — trap-free,
+   * Whether this value is a Date (engine brand check: trap-free,
    * spoof-proof, and unaffected by prototype/constructor mutation).
    * A Proxy wrapping a Date returns false.
    */
@@ -2728,7 +2728,7 @@ export class JSValueHandle {
   }
 
   /**
-   * Whether this value is a RegExp (engine brand check — trap-free,
+   * Whether this value is a RegExp (engine brand check: trap-free,
    * spoof-proof, and unaffected by prototype/constructor mutation).
    * A Proxy wrapping a RegExp returns false.
    */
@@ -2762,13 +2762,13 @@ export class JSValueHandle {
    *
    * Two handles to the same underlying object always report the same
    * identity, and two live handles to different objects always report
-   * different identities — so this is the value to key a `Map` on when
+   * different identities, so this is the value to key a `Map` on when
    * deduplicating or detecting cycles across handles (`dump()` uses it for
    * exactly that).
    *
    * The identity is only meaningful while the value is alive; it is an
    * address, so it may be reused after every handle to the value has been
-   * disposed. Do not persist it, and do not treat it as unforgeable — a
+   * disposed. Do not persist it, and do not treat it as unforgeable: a
    * number read out of the guest can trivially collide with one.
    */
   get identity(): number {
@@ -2787,16 +2787,16 @@ export class JSValueHandle {
    * The internal QuickJS class ID of this value, or 0 for non-objects.
    * Useful as a generic engine-level brand when no dedicated `is*`
    * getter exists. Class IDs are stable within a VM instance but are an
-   * engine implementation detail — prefer the dedicated getters.
+   * engine implementation detail, so prefer the dedicated getters.
    */
   get classId(): number {
     return this.vm._getExports().qjs_get_class_id(this.ptr);
   }
 
   /**
-   * The engine-level class name of this value — e.g. `"Object"`, `"Map"`,
+   * The engine-level class name of this value, e.g. `"Object"`, `"Map"`,
    * `"Date"`, `"RegExp"`, or the registered name of an extension-defined
-   * class like `"URL"` — or `undefined` for non-objects and unnamed
+   * class like `"URL"`, or `undefined` for non-objects and unnamed
    * internal classes.
    *
    * Unlike `constructorName` (which reads the `constructor` and `name`
@@ -2804,7 +2804,7 @@ export class JSValueHandle {
    * this is trap-free: it reads the engine's class table directly, never
    * executes guest code, and cannot be forged by reassigning prototypes or
    * constructors. Note that the engine registers the Proxy class under the
-   * name `"Object"` (mirroring `Object.prototype.toString`) — use `isProxy`
+   * name `"Object"` (mirroring `Object.prototype.toString`), so use `isProxy`
    * to detect proxies and `getProxyTarget()` to read the target's brand.
    */
   get className(): string | undefined {
@@ -2918,7 +2918,7 @@ export class JSValueHandle {
   }
 
   /**
-   * Get ALL own property keys — strings and symbols, including
+   * Get ALL own property keys (strings and symbols), including
    * non-enumerable (equivalent to Reflect.ownKeys()).
    *
    * String keys are returned as strings; symbol keys are returned as
@@ -3049,7 +3049,7 @@ export class JSValueHandle {
 
   /**
    * Get the `[[ProxyTarget]]` of this Proxy without firing any traps.
-   * Throws {@link JSException} if this value is not a Proxy — check
+   * Throws {@link JSException} if this value is not a Proxy; check
    * {@link isProxy} first. Note the target may itself be a Proxy.
    */
   getProxyTarget(): JSValueHandle {
@@ -3064,7 +3064,7 @@ export class JSValueHandle {
 
   /**
    * Get the `[[ProxyHandler]]` of this Proxy without firing any traps.
-   * Throws {@link JSException} if this value is not a Proxy — check
+   * Throws {@link JSException} if this value is not a Proxy; check
    * {@link isProxy} first.
    */
   getProxyHandler(): JSValueHandle {
@@ -3245,13 +3245,13 @@ export class JSValueHandle {
     // points as 3-byte WTF-8 sequences, decoded back to their original
     // code units). The previous JS_ToCString/NUL-terminated read
     // silently truncated at the first NUL and replaced lone surrogates
-    // with U+FFFD — and the two corruptions could cancel each other's
+    // with U+FFFD, and the two corruptions could cancel each other's
     // length changes, defeating length-based detection downstream.
     const e = this.vm._getExports();
     const lenPtr = e.wasm_malloc(4);
     // Same failure check as writeString(): a 0 return would make
     // qjs_get_string_len write the length to address 0 and the DataView
-    // read below read from it — silent corruption instead of an error.
+    // read below read from it: silent corruption instead of an error.
     if (lenPtr === 0) throw new Error('wasm_malloc failed');
     try {
       const cstrPtr = e.qjs_get_string_len(this.ptr, lenPtr);
@@ -3294,13 +3294,13 @@ export class JSValueHandle {
     // here would leave the cached handle pointing at freed memory, so disposing
     // a singleton is intentionally a no-op. Borrowed handles (host-callback
     // `this`/arguments) wrap pointers owned by the C caller, which frees them
-    // itself after the call returns — freeing here would double-free.
+    // itself after the call returns; freeing here would double-free.
     if (this.singleton || this.borrowed) return;
     if (!this.disposed_) {
       this.disposed_ = true;
       this._onDispose?.();
       this._onDispose = undefined;
-      // If the VM is already disposed, the WASM instance is gone —
+      // If the VM is already disposed, the WASM instance is gone;
       // no need to (and we can't) call qjs_free_value.
       const exports = this.vm._getExports();
       if (exports) {

--- a/test/compile.test.ts
+++ b/test/compile.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the degenerator compile() integration — compiles JS code into
+ * Tests for the degenerator compile() integration, which compiles JS code into
  * async functions with sandbox support and executes them in the QuickJS VM.
  */
 

--- a/test/crypto.test.ts
+++ b/test/crypto.test.ts
@@ -190,7 +190,7 @@ describe('crypto.getRandomValues()', () => {
     })()`);
     expect(result.isSame).toBe(true);
     expect(result.length).toBe(16);
-    // Very unlikely all 16 bytes are zero
+    // All 16 random bytes being zero has probability 2^-128
     expect(result.hasNonZero).toBe(true);
   });
 

--- a/test/crypto.test.ts
+++ b/test/crypto.test.ts
@@ -530,7 +530,7 @@ describe('SubtleCrypto.digest()', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.generateKey() — HMAC
+// SubtleCrypto.generateKey(): HMAC
 // WPT: WebCryptoAPI/generateKey/successes_HMAC.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -577,7 +577,7 @@ describe('SubtleCrypto.generateKey() - HMAC', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.generateKey() — AES
+// SubtleCrypto.generateKey(): AES
 // WPT: WebCryptoAPI/generateKey/successes_AES-GCM.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -606,7 +606,7 @@ describe('SubtleCrypto.generateKey() - AES', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.generateKey() — ECDSA key pair
+// SubtleCrypto.generateKey(): ECDSA key pair
 // WPT: WebCryptoAPI/generateKey/successes_ECDSA.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -637,7 +637,7 @@ describe('SubtleCrypto.generateKey() - ECDSA', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.sign() / verify() — HMAC
+// SubtleCrypto.sign() / verify(): HMAC
 // WPT: WebCryptoAPI/sign_verify/hmac.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -679,7 +679,7 @@ describe('SubtleCrypto.sign() / verify() - HMAC', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.sign() / verify() — ECDSA
+// SubtleCrypto.sign() / verify(): ECDSA
 // WPT: WebCryptoAPI/sign_verify/ecdsa.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -702,7 +702,7 @@ describe('SubtleCrypto.sign() / verify() - ECDSA', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.encrypt() / decrypt() — AES-GCM
+// SubtleCrypto.encrypt() / decrypt(): AES-GCM
 // WPT: WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -750,7 +750,7 @@ describe('SubtleCrypto.encrypt() / decrypt() - AES-GCM', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.encrypt() / decrypt() — AES-CBC
+// SubtleCrypto.encrypt() / decrypt(): AES-CBC
 // WPT: WebCryptoAPI/encrypt_decrypt/aes_cbc.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -782,7 +782,7 @@ describe('SubtleCrypto.encrypt() / decrypt() - AES-CBC', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.encrypt() / decrypt() — AES-CTR
+// SubtleCrypto.encrypt() / decrypt(): AES-CTR
 // WPT: WebCryptoAPI/encrypt_decrypt/aes_ctr.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -820,7 +820,7 @@ describe('SubtleCrypto.encrypt() / decrypt() - AES-CTR', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.importKey() / exportKey() — raw AES round-trip
+// SubtleCrypto.importKey() / exportKey(): raw AES round-trip
 // WPT: WebCryptoAPI/import_export/symmetric_importKey.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -852,7 +852,7 @@ describe('SubtleCrypto.importKey() / exportKey() - AES raw', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.importKey() / exportKey() — HMAC raw round-trip
+// SubtleCrypto.importKey() / exportKey(): HMAC raw round-trip
 // ═══════════════════════════════════════════════════════════════════════════════
 
 describe('SubtleCrypto.importKey() / exportKey() - HMAC raw', () => {
@@ -869,7 +869,7 @@ describe('SubtleCrypto.importKey() / exportKey() - HMAC raw', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.deriveBits() / deriveKey() — HKDF
+// SubtleCrypto.deriveBits() / deriveKey(): HKDF
 // WPT: WebCryptoAPI/derive_bits_keys/hkdf.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -906,7 +906,7 @@ describe('SubtleCrypto.deriveBits() - HKDF', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// SubtleCrypto.deriveKey() — PBKDF2
+// SubtleCrypto.deriveKey(): PBKDF2
 // WPT: WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js
 // ═══════════════════════════════════════════════════════════════════════════════
 

--- a/test/devalue-operations.ts
+++ b/test/devalue-operations.ts
@@ -10,14 +10,14 @@
  * Two halves, mirroring devalue's two pluggable operation sets:
  *
  * - `stringifyOperations` reads a handle without executing guest code:
- *   the engine's class table for classification (`handle.className` — no
+ *   the engine's class table for classification (`handle.className`, with no
  *   sample instances needed, not even at boot), boot-captured intrinsics
  *   for extraction, and descriptor reads instead of `[[Get]]`.
  * - `parseOperations` builds values inside the VM through boot-captured
  *   factories, returning a handle the guest can use directly.
  *
  * "Boot-captured" means the intrinsics and factories are taken from the VM
- * before any user code runs, and are held only on the host — so patching
+ * before any user code runs, and are held only on the host, so patching
  * `Date.prototype.toISOString` (or anything else) inside the VM afterwards
  * cannot influence serialization.
  */
@@ -31,9 +31,9 @@ import { QuickJS, type JSValueHandle } from '../src/index.ts';
 
 /**
  * The tags devalue classifies values by. QuickJS registers each of these
- * classes under exactly this name, so `handle.className` — a trap-free
+ * classes under exactly this name, so `handle.className`, a trap-free
  * read of the engine's class table (`JS_GetClassName`, fixed in
- * quickjs-ng 0.16.2) — classifies values directly. No sample instances,
+ * quickjs-ng 0.16.2), classifies values directly. No sample instances,
  * no guest code, not even at boot: a VM built without some of these
  * intrinsics classifies the rest just fine.
  */
@@ -228,7 +228,7 @@ export function createDevalueOperations(vm: QuickJS): DevalueOperations {
 
   /**
    * Define an own data property. Uses `Object.defineProperty` rather than
-   * assignment so that an inherited setter cannot intercept the write — the
+   * assignment so that an inherited setter cannot intercept the write: the
    * revived value is built exactly as the payload describes it.
    */
   const define = (
@@ -280,8 +280,8 @@ export function createDevalueOperations(vm: QuickJS): DevalueOperations {
 
   const tag = (handle: JSValueHandle): string => {
     // Trap-free and unspoofable: the engine's registered class name.
-    // Everything unbranded — including proxies, whose class is registered
-    // as "Object" — reports as a plain-object candidate, which `shapeOf`
+    // Everything unbranded (including proxies, whose class is registered
+    // as "Object") reports as a plain-object candidate, which `shapeOf`
     // then accepts or rejects without firing traps.
     const name = handle.className;
     return name !== undefined && BRANDED_TAGS.has(name) ? name : 'Object';
@@ -305,7 +305,7 @@ export function createDevalueOperations(vm: QuickJS): DevalueOperations {
   };
 
   // Typed as the *complete* interface (not Partial): if devalue adds a hook
-  // this implementation is missing, compilation fails — which is exactly the
+  // this implementation is missing, compilation fails, which is exactly the
   // gap-detection this POC exists to provide.
   const stringifyOperations: StringifyOperations = {
     identify: (handle: JSValueHandle) => {
@@ -349,7 +349,7 @@ export function createDevalueOperations(vm: QuickJS): DevalueOperations {
     // Only reached for URL / URLSearchParams / Temporal.*, none of which
     // exist in the base VM. `handle.toString()` would execute guest code
     // (the value's own `toString`), so this deliberately refuses rather than
-    // silently running it — a VM with those types would capture the relevant
+    // silently running it; a VM with those types would capture the relevant
     // prototype methods the same way the intrinsics above are captured.
     toStringValue: (handle: JSValueHandle) => {
       throw new Error(
@@ -395,7 +395,7 @@ export function createDevalueOperations(vm: QuickJS): DevalueOperations {
 
     lengthOf: (handle: JSValueHandle) => {
       const descriptor = handle.getOwnPropertyDescriptor('length');
-      // `length` is an own data property on arrays — no getter runs
+      // `length` is an own data property on arrays, so no getter runs
       return descriptor?.value?.consume((h) => h.toNumber()) ?? 0;
     },
 
@@ -451,7 +451,7 @@ export function createDevalueOperations(vm: QuickJS): DevalueOperations {
   // --- parse -------------------------------------------------------------
 
   const parseOperations: ParseOperations = {
-    // host bigints arrive here too — devalue converts the decimal string
+    // host bigints arrive here too; devalue converts the decimal string
     // host-side, mirroring `toPrimitive`'s domain
     fromPrimitive: (value) =>
       typeof value === 'bigint' ? vm.newBigInt(value) : vm.hostToHandle(value),
@@ -462,7 +462,7 @@ export function createDevalueOperations(vm: QuickJS): DevalueOperations {
       return vm.construct(i.Date, argument);
     },
 
-    // URL / URLSearchParams / Temporal.* — none exist in the base VM
+    // URL / URLSearchParams / Temporal.*: none exist in the base VM
     fromStringValue: (tag) => {
       throw new Error(`${tag} is not available in this VM`);
     },

--- a/test/devalue-round-trip.test.ts
+++ b/test/devalue-round-trip.test.ts
@@ -410,7 +410,7 @@ describe('host-side devalue: guest code is not executed', () => {
     const harness = await createHarness();
     try {
       // `Object.prototype.toString` (what devalue classifies with by default)
-      // honours `Symbol.toStringTag`, so this object claims to be a Date.
+      // honors `Symbol.toStringTag`, so this object claims to be a Date.
       using spoofed = harness.vm.evalCode(
         'Object.defineProperty({ a: 1 }, Symbol.toStringTag, { value: "Date" })'
       );

--- a/test/devalue-round-trip.test.ts
+++ b/test/devalue-round-trip.test.ts
@@ -409,8 +409,8 @@ describe('host-side devalue: guest code is not executed', () => {
   it('is not fooled by a spoofed brand', async () => {
     const harness = await createHarness();
     try {
-      // `Object.prototype.toString` — what devalue classifies with by default
-      // — honours `Symbol.toStringTag`, so this object claims to be a Date.
+      // `Object.prototype.toString` (what devalue classifies with by default)
+      // honours `Symbol.toStringTag`, so this object claims to be a Date.
       using spoofed = harness.vm.evalCode(
         'Object.defineProperty({ a: 1 }, Symbol.toStringTag, { value: "Date" })'
       );
@@ -468,7 +468,7 @@ describe('host-side devalue: guest code is not executed', () => {
       expect(() => harness.serialize(fake)).toThrow(/non-POJO/);
 
       // A real typed array stripped of its prototype keeps its internal
-      // slots — the class table still says Uint8Array and the captured
+      // slots: the class table still says Uint8Array and the captured
       // getters read the real buffer.
       using stripped = harness.vm.evalCode(
         'Object.setPrototypeOf(new Uint8Array([7, 8]), Object.prototype)'

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -483,7 +483,7 @@ describe('TextDecoder streaming', () => {
     const result = await evalStr(`
       const decoder = new TextDecoder();
       let out = '';
-      // é = U+00E9 = 0xC3 0xA9 — split across two chunks
+      // é = U+00E9 = 0xC3 0xA9, split across two chunks
       out += decoder.decode(new Uint8Array([0xC3]), { stream: true });
       out += decoder.decode(new Uint8Array([0xA9]));
       out
@@ -495,7 +495,7 @@ describe('TextDecoder streaming', () => {
     const result = await evalStr(`
       const decoder = new TextDecoder();
       let out = '';
-      // € = U+20AC = 0xE2 0x82 0xAC — split across three chunks
+      // € = U+20AC = 0xE2 0x82 0xAC, split across three chunks
       out += decoder.decode(new Uint8Array([0xE2]), { stream: true });
       out += decoder.decode(new Uint8Array([0x82]), { stream: true });
       out += decoder.decode(new Uint8Array([0xAC]));

--- a/test/eval.test.ts
+++ b/test/eval.test.ts
@@ -156,7 +156,7 @@ describe('EvalFlags.TYPE_MODULE', () => {
 
   it('should make import.meta available', async () => {
     const vm = await QuickJS.create(wasmBytes);
-    // Module eval doesn't return the last expression value — use globalThis
+    // Module eval doesn't return the last expression value; use globalThis
     const result = vm.evalCode(
       'globalThis.__metaType = typeof import.meta',
       '<eval>',
@@ -208,7 +208,7 @@ describe('EvalFlags.COMPILE_ONLY', () => {
     using vm = await QuickJS.create(wasmBytes);
     // With COMPILE_ONLY, the code is compiled but not executed
     using result = vm.evalCode('1 + 2', '<eval>', EvalFlags.COMPILE_ONLY);
-    // The result should not be the number 3 — it's a bytecode object
+    // The result should not be the number 3; it's a bytecode object
     expect(vm.typeof(result)).not.toBe('number');
   });
 

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -74,7 +74,7 @@ describe('host callback this binding', () => {
       vm.setProp(vm.global, 'checkThis', checkThis);
     }
 
-    // Free function call — `this` is globalThis (which has `eval`)
+    // Free function call: `this` is globalThis (which has `eval`)
     expect(vm.dump(vm.evalCode('checkThis()'))).toBe(true);
   });
 });
@@ -104,10 +104,10 @@ describe('host callback error propagation', () => {
       vm.setProp(vm.global, 'mayFail', fn);
     }
 
-    // Successful call — returns a normal value
+    // Successful call returns a normal value
     expect(vm.evalCode('mayFail(5)').consume(h => h.toNumber())).toBe(10);
 
-    // Failed call — the guest catches it in JS, so evalCode returns a normal value
+    // Failed call: the guest catches it in JS, so evalCode returns a normal value
     using result = vm.evalCode(`
       try { mayFail(-1) } catch(e) { e.message }
     `);
@@ -123,7 +123,7 @@ describe('host callback error propagation', () => {
       vm.setProp(vm.global, 'boom', fn);
     }
 
-    // Uncaught on host side — throws JSException
+    // Uncaught on host side throws JSException
     try {
       vm.evalCode('boom()');
     } catch (err) {

--- a/test/gc-threshold.test.ts
+++ b/test/gc-threshold.test.ts
@@ -26,9 +26,9 @@ describe('vm.gcThreshold', () => {
 
   it('should allow the VM to function with a custom threshold', async () => {
     using vm = await QuickJS.create(wasmBytes);
-    vm.gcThreshold = 64 * 1024; // Very low threshold — GC runs frequently
+    vm.gcThreshold = 64 * 1024; // Low threshold, so GC runs frequently
 
-    // Allocate a bunch of objects — this should still work, just with more GC runs
+    // Allocate a bunch of objects. This should still work, with more GC runs
     vm.evalCode(`
       for (let i = 0; i < 1000; i++) {
         let obj = { data: "x".repeat(100) };

--- a/test/handle-lifetime.test.ts
+++ b/test/handle-lifetime.test.ts
@@ -115,7 +115,7 @@ describe('withScope + host callbacks (borrowed handles)', () => {
     // Regression: the trampoline's `this`/argument handles wrap pointers
     // OWNED BY THE C CALLER. Before the `borrowed` flag they registered
     // with the active scope, and the scope's disposal at exit double-freed
-    // the guest values — observed as WASM memory corruption when a host
+    // the guest values, observed as WASM memory corruption when a host
     // serializer drove Map/Set `forEach` visitors inside `withScope`.
     const seen: number[] = [];
     using visitor = vm.newEphemeralFunction((value) => {
@@ -179,7 +179,7 @@ describe('withScope + host callbacks (borrowed handles)', () => {
       expect(retained!.disposed).toBe(false);
     });
 
-    // The dup is an owned reference — the scope disposed it at exit,
+    // The dup is an owned reference: the scope disposed it at exit,
     // exactly like any handle the callback created.
     expect(retained!.disposed).toBe(true);
   });

--- a/test/intrinsics.test.ts
+++ b/test/intrinsics.test.ts
@@ -114,7 +114,7 @@ describe('Intrinsics', () => {
       wasm: wasmBytes,
       intrinsics: Intrinsics.ALL & ~Intrinsics.BIG_INT,
     });
-    // BigInt is still available — it's part of the base engine
+    // BigInt is still available; it's part of the base engine
     expect(vm.evalCode('typeof BigInt').consume(h => h.toString())).toBe('function');
     expect(vm.evalCode('(123n).toString()').consume(h => h.toString())).toBe('123');
   });

--- a/test/introspection.test.ts
+++ b/test/introspection.test.ts
@@ -273,7 +273,7 @@ describe('className', () => {
     `);
 
     // The engine registers the Proxy class under the name "Object"
-    // (mirroring Object.prototype.toString) — use isProxy to detect
+    // (mirroring Object.prototype.toString), so use isProxy to detect
     // proxies, then unwrap to get the real brand.
     expect(proxy.className).toBe('Object');
     expect(proxy.isProxy).toBe(true);

--- a/test/limits.test.ts
+++ b/test/limits.test.ts
@@ -32,7 +32,7 @@ describe('memoryLimit', () => {
     });
 
     // Regression: quickjs-ng's default usable-size returns 0 on
-    // wasm32-wasi, so allocations were recorded as overhead only — the
+    // wasm32-wasi, so allocations were recorded as overhead only: the
     // per-allocation limit check saw each incoming size, but nothing
     // accumulated in malloc_size. Many sub-limit buffers (each well
     // under 8 MiB) therefore grew real linear memory without bound:
@@ -75,7 +75,7 @@ describe('memoryLimit', () => {
 
     // Regression: once #33 made the accounting real, a guest that filled
     // memory with small objects left no room for JS_ThrowOutOfMemory to
-    // allocate the "out of memory" InternalError — the engine's limit
+    // allocate the "out of memory" InternalError: the engine's limit
     // check refused that allocation too, and quickjs fell back to
     // throwing a bare JS_NULL. In-guest catch saw `null` and the host
     // JSException had name/message "<null>", indistinguishable from a

--- a/test/lossless-strings.test.ts
+++ b/test/lossless-strings.test.ts
@@ -7,7 +7,7 @@ import { wasmBytes } from './helpers.ts';
  *
  * Guest→host previously read strings through NUL-terminated
  * `JS_ToCString`: embedded U+0000 truncated the string, and lone
- * surrogates were replaced with U+FFFD — and the two corruptions can
+ * surrogates were replaced with U+FFFD, and the two corruptions can
  * cancel each other's length changes, so no length check downstream can
  * detect the loss. Host→guest previously encoded with TextEncoder, which
  * replaces lone surrogates with U+FFFD before the guest ever sees them
@@ -15,15 +15,15 @@ import { wasmBytes } from './helpers.ts';
  * identically).
  *
  * Now: guest→host reads length-aware WTF-8 (`qjs_get_string_len`), and
- * host→guest writes WTF-8 (`writeString`), so every JS string — a
- * sequence of arbitrary UTF-16 code units — round-trips exactly. Keys are
+ * host→guest writes WTF-8 (`writeString`), so every JS string (a
+ * sequence of arbitrary UTF-16 code units) round-trips exactly. Keys are
  * covered by routing string keys that C strings cannot express (NULs,
  * unpaired surrogates) through length-aware guest string values.
  */
 
 // Escape source so the guest receives exact code units regardless of the
 // transport under test (avoids the both-sides-corrupted trap).
-// NOTE: iterate by CODE UNIT (index), not by code point — Array.from /
+// NOTE: iterate by CODE UNIT (index), not by code point: Array.from /
 // for..of iterate code points and would collapse surrogate pairs.
 const guestLiteral = (s: string) => {
   let out = '"';

--- a/test/memory-growth.test.ts
+++ b/test/memory-growth.test.ts
@@ -158,10 +158,10 @@ describe('WASM memory growth', () => {
   it('should enforce memoryLimit and stop JS allocations', async () => {
     using vm = await QuickJS.create({
       wasm: wasmBytes,
-      memoryLimit: 512 * 1024, // 512 KB — tight limit
+      memoryLimit: 512 * 1024, // 512 KB, a tight limit
     });
 
-    // Try to allocate way more than 512 KB — QuickJS should throw OOM.
+    // Try to allocate way more than 512 KB; QuickJS should throw OOM.
     // Use the same pattern as limits.test.ts which is known to trigger OOM.
     const result = vm.evalCode(`
       try {
@@ -210,7 +210,7 @@ describe('WASM memory growth', () => {
           arr.push("x".repeat(1000));
         }
       } catch (e) {
-        // OOM — stop allocating
+        // OOM: stop allocating
       }
     `).dispose();
     const limitedPages = getPageCount(vmLimited);

--- a/test/module-loader.test.ts
+++ b/test/module-loader.test.ts
@@ -258,7 +258,7 @@ describe('moduleLoader', () => {
     using vm = await QuickJS.create({
       wasm: wasmBytes,
       moduleLoader: {
-        // @ts-expect-error — deliberately wrong: load must be synchronous
+        // @ts-expect-error deliberately wrong: load must be synchronous
         load: async () => 'export const x = 42;',
       },
     });
@@ -272,7 +272,7 @@ describe('moduleLoader', () => {
     using vm = await QuickJS.create({
       wasm: wasmBytes,
       moduleLoader: {
-        // @ts-expect-error — deliberately wrong: normalize must be synchronous
+        // @ts-expect-error deliberately wrong: normalize must be synchronous
         normalize: async (_base: string, specifier: string) => specifier,
         load: () => 'export const x = 42;',
       },
@@ -371,7 +371,7 @@ describe('moduleLoader', () => {
     const snapshot = vm1.snapshot();
     vm1.dispose();
 
-    // Restore — must provide moduleLoader again for future imports
+    // Restore: must provide moduleLoader again for future imports
     using vm2 = await QuickJS.restore(snapshot, {
       wasm: wasmBytes,
       moduleLoader: makeLoader(),

--- a/test/portable-handles.test.ts
+++ b/test/portable-handles.test.ts
@@ -4,7 +4,7 @@ import { wasmBytes } from './helpers.ts';
 
 /**
  * Snapshot-portable handles: exportHandle() turns a live handle into a
- * token that importHandle() re-materializes — on the same VM or on any
+ * token that importHandle() re-materializes, on the same VM or on any
  * VM restored from a snapshot taken while the handle was alive. The
  * headline use case is boot-time capture of pristine intrinsics before
  * user code runs (see the exportHandle docs).
@@ -33,13 +33,13 @@ describe('exportHandle / importHandle', () => {
     using iso = restored.callFunction(imported, date);
     expect(iso.toString()).toBe('2023-11-14T22:13:20.000Z');
 
-    // The patch is still what guest code observes — the import didn't
+    // The patch is still what guest code observes; the import didn't
     // mutate the heap, it only referenced a value the heap already held.
     using patched = restored.evalCode('new Date(0).toISOString()');
     expect(patched.toString()).toBe('patched');
   });
 
-  it('imports are independently owned — multiple imports, independent dispose', async () => {
+  it('imports are independently owned: multiple imports, independent dispose', async () => {
     using baseline = await QuickJS.create(wasmBytes);
     const obj = baseline.evalCode('({ tag: "kept" })');
     const token = baseline.exportHandle(obj);
@@ -75,7 +75,7 @@ describe('exportHandle / importHandle', () => {
     let dupToken: number | undefined;
     using fn = vm.newEphemeralFunction((arg) => {
       // The trampoline's argument handles wrap C-owned boxes freed when
-      // this callback returns — a token minted from one would dangle in
+      // this callback returns; a token minted from one would dangle in
       // every restored VM.
       try {
         vm.exportHandle(arg);

--- a/test/promise-rejection.test.ts
+++ b/test/promise-rejection.test.ts
@@ -67,7 +67,7 @@ describe('onUnhandledRejection', () => {
   });
 
   it('should not fire when no handler is registered', async () => {
-    // Should not crash — just silently ignores unhandled rejections
+    // Should not crash; unhandled rejections are silently ignored
     using vm = await QuickJS.create(wasmBytes);
     vm.evalCode('Promise.reject("ignored")').dispose();
     vm.executePendingJobs();

--- a/test/symbols.test.ts
+++ b/test/symbols.test.ts
@@ -18,7 +18,7 @@ describe('Symbol.for() (global symbols)', () => {
     using hostSym = vm.newSymbolFor('MY_KEY');
     vm.setProp(vm.global, hostSym, vm.newString('hello from host'));
 
-    // QuickJS code uses Symbol.for('MY_KEY') — should find the same property
+    // QuickJS code uses Symbol.for('MY_KEY'); it should find the same property
     using result = vm.evalCode('globalThis[Symbol.for("MY_KEY")]');
     expect(result.toString()).toBe('hello from host');
   });


### PR DESCRIPTION
Audits all documentation and code comments against the Vercel technical writing guidelines, with emphasis on removing em dashes.

## What changed

**Em dashes (~250 instances removed).** Em dashes used for emphasis create ambiguity for agents parsing sentence boundaries. Each instance was rewritten contextually rather than mechanically:

- `term — definition` list entries → colons
- Parenthetical asides → parentheses or commas
- Sentence joins → periods, semicolons, or connectives (`so`, `because`, `since`)

**Banned words and filler:**

| Location | Before | After |
|---|---|---|
| EXTENSIONS.md | "Quick Start" heading | "Get started" |
| EXTENSIONS.md | "simply contributes no version entries" | "contributes no version entries" |
| README.md | "compresses very well" | "compresses well" |
| examples/browser/main.tsx | "in order to render" | "to render" |
| test comments | "Very low threshold", "just silently ignores" | rewritten |

**Error-message strings** in src/index.ts also lose their em dashes (three messages). Verified no test asserts on the affected message portions.

## Deliberately untouched

- **CHANGELOG.md**: generated by changesets and a historical record
- **Table "none" placeholders**: the lone `—` cell in README's conversion table and the `'—'.padStart()` literals in benchmark output are data, not prose
- **quickjs-ng submodule and vendored code** (ada, mbedtls)
- **String literals in tests** (guest code, test data)

## Scope

35 files: README.md, EXTENSIONS.md, 4 extension READMEs, src/index.ts (76 instances), c/interface.c (24), Makefile, extension C sources, mbedtls config header, examples, benchmarks, and 18 test files.

## Verification

- Repo-wide scan confirms zero remaining prose em dashes, banned words, or filler phrases in the audited scope
- No functional behavior changes: 1933/1933 tests pass, `tsc` builds, the browser example typechecks
- The only runtime-observable edits are the three error-message strings in src/index.ts noted above (message text only; no test asserts on the affected portions). Everything else is comment and doc lines.
- The initial commit was exactly 289 insertions / 289 deletions; follow-up commits add the heading-case, spelling, and quantification fixes
