### PR TITLE
docs: fix incorrect claim that host callbacks receive this as args[0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ Register JavaScript functions backed by host (Node.js) callbacks:
 ```typescript
 using vm = await QuickJS.create(wasmBytes);
 
-// The first argument to the callback is always `this`
+// The callback receives the call arguments as handles. The guest `this`
+// value is the callback's `this` binding, so use a regular `function`
+// expression (not an arrow function) if you need to access it.
 {
   using add = vm.newFunction('add', (...args) => {
     return vm.newNumber(args[0].toNumber() + args[1].toNumber());


### PR DESCRIPTION
The host functions example in the README claimed:

```
// The first argument to the callback is always `this`
```

This is wrong, and the sample below it proves so itself: it reads the call arguments from `args[0]`/`args[1]` and prints `7` for `add(3, 4)`, which is only possible because `args` holds exactly the call arguments. If `this` were `args[0]`, the result would be `globalThis + 3`.

## Actual contract

`handleHostCall` delivers the guest `this` value as the callback's **`this` binding**:

```ts
const result = callback.call(thisHandle, ...args);
```

matching the `HostFunction` type's this-parameter: `(this: JSValueHandle, ...args: JSValueHandle[]) => JSValueHandle`.

Verified empirically:
- guest `probe(3, 4)` invokes the callback with `args.length === 2` (`3`, `4`)
- guest `probe2.call({ x: 42 })` resolves `this.getProp('x')` to `42` in a regular `function` callback

The comment now describes the real behavior and notes that an arrow function cannot observe the `this` binding. The incorrect claim traces back to the README rewrite in 55d2a3d and matches no version of the implementation since. No other file makes the same claim (checked README, EXTENSIONS, src, examples).