### PR TITLE
feat: add maxStackSize through QuickJS.create

### DIFF
--- a/.changeset/catchable-wasi-stacks.md
+++ b/.changeset/catchable-wasi-stacks.md
@@ -1,0 +1,7 @@
+---
+"quickjs-wasi": minor
+---
+
+Add the `maxStackSize` option and `MAX_STACK_SIZE` ceiling so WASI stack
+overflow can be caught by guest JavaScript without exhausting the physical
+WebAssembly stack.

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,14 @@ import { VERSION } from './version.js';
 
 // ---- Public types ----
 
+/**
+ * Largest supported QuickJS native stack limit for the shipped WASM binary.
+ *
+ * The binary has a 1 MiB linker-defined stack; reserving half of it leaves
+ * headroom for native frames and stack-overflow exception handling.
+ */
+export const MAX_STACK_SIZE = 512 * 1024;
+
 export type HostFunction = (this: JSValueHandle, ...args: JSValueHandle[]) => JSValueHandle;
 
 /**
@@ -228,6 +236,12 @@ export interface QuickJSOptions {
    * (e.g. `InternalError: out of memory`).
    */
   memoryLimit?: number;
+  /**
+   * Maximum native stack space QuickJS may consume, in bytes.
+   * Must be an integer between 0 and {@link MAX_STACK_SIZE}. Set to 0 to
+   * disable the QuickJS stack guard.
+   */
+  maxStackSize?: number;
   /**
    * Called periodically during JS execution. Return `true` to interrupt
    * the current execution with an `InternalError: interrupted` exception.
@@ -917,7 +931,20 @@ export class QuickJS {
       return { wasm: undefined as unknown as BufferSource };
     }
     if (options instanceof WebAssembly.Module) return { wasm: options };
-    if (typeof options === 'object' && ('wasm' in options || 'wasi' in options || 'memoryLimit' in options || 'interruptHandler' in options || 'onUnhandledRejection' in options || 'moduleLoader' in options || 'intrinsics' in options || 'extensions' in options || 'timezoneOffset' in options)) return options as QuickJSOptions;
+    if (typeof options === 'object' && ('wasm' in options || 'wasi' in options || 'memoryLimit' in options || 'maxStackSize' in options || 'interruptHandler' in options || 'onUnhandledRejection' in options || 'moduleLoader' in options || 'intrinsics' in options || 'extensions' in options || 'timezoneOffset' in options)) {
+      const opts = options as QuickJSOptions;
+      if (
+        opts.maxStackSize !== undefined &&
+        (!Number.isInteger(opts.maxStackSize) ||
+          opts.maxStackSize < 0 ||
+          opts.maxStackSize > MAX_STACK_SIZE)
+      ) {
+        throw new RangeError(
+          `maxStackSize must be an integer between 0 and ${MAX_STACK_SIZE}`,
+        );
+      }
+      return opts;
+    }
     // BufferSource (ArrayBuffer or ArrayBufferView)
     return { wasm: options as BufferSource };
   }
@@ -925,6 +952,9 @@ export class QuickJS {
   private static applyLimits(vm: QuickJS, opts: QuickJSOptions): void {
     if (opts.memoryLimit !== undefined) {
       vm.exports.qjs_set_memory_limit(opts.memoryLimit);
+    }
+    if (opts.maxStackSize !== undefined) {
+      vm.exports.qjs_set_max_stack_size(opts.maxStackSize);
     }
     if (opts.interruptHandler) {
       vm.interruptHandler = opts.interruptHandler;

--- a/test/limits.test.ts
+++ b/test/limits.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { QuickJS, JSException } from '../src/index.ts';
+import { QuickJS, JSException, MAX_STACK_SIZE } from '../src/index.ts';
 import { wasmBytes } from './helpers.ts';
 
 describe('memoryLimit', () => {
@@ -158,6 +158,84 @@ describe('memoryLimit', () => {
     const msg = result.consume(h => h.toString());
     expect(msg).not.toBe('ok');
   });
+});
+
+describe('maxStackSize', () => {
+  const recurseUntilOverflow = `
+    (() => {
+      let depth = 0;
+      function recurse() {
+        depth++;
+        return recurse();
+      }
+      try {
+        recurse();
+        return "no-throw";
+      } catch (error) {
+        return {
+          name: error.name,
+          message: error.message,
+          depth,
+        };
+      }
+    })()
+  `;
+
+  it('makes recursive stack exhaustion catchable and keeps the VM usable', async () => {
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      maxStackSize: 64 * 1024,
+    });
+
+    const overflow = vm.evalCode(recurseUntilOverflow).consume((handle) => vm.dump(handle));
+    expect(overflow).toMatchObject({
+      name: 'RangeError',
+      message: 'Maximum call stack size exceeded',
+    });
+
+    expect(vm.evalCode('1 + 2').consume((handle) => handle.toNumber())).toBe(3);
+  });
+
+  it('re-applies the configured limit after snapshot restore', async () => {
+    const vm1 = await QuickJS.create(wasmBytes);
+    vm1.evalCode('globalThis.beforeSnapshot = 42').dispose();
+    const snapshot = vm1.snapshot();
+    vm1.dispose();
+
+    using vm2 = await QuickJS.restore(snapshot, {
+      wasm: wasmBytes,
+      maxStackSize: 64 * 1024,
+    });
+
+    expect(vm2.evalCode('beforeSnapshot').consume((handle) => handle.toNumber())).toBe(42);
+    expect(vm2.evalCode(recurseUntilOverflow).consume((handle) => vm2.dump(handle))).toMatchObject({
+      name: 'RangeError',
+      message: 'Maximum call stack size exceeded',
+    });
+  });
+
+  it('allows disabling the stack guard with zero', async () => {
+    using vm = await QuickJS.create({
+      wasm: wasmBytes,
+      maxStackSize: 0,
+    });
+
+    const depth = vm.evalCode(`
+      (function recurse(remaining) {
+        return remaining === 0 ? 1000 : recurse(remaining - 1);
+      })(1000)
+    `).consume((handle) => handle.toNumber());
+    expect(depth).toBe(1000);
+  });
+
+  it.each([-1, 1.5, MAX_STACK_SIZE + 1])(
+    'rejects invalid value %s',
+    async (maxStackSize) => {
+      await expect(QuickJS.create({ wasm: wasmBytes, maxStackSize })).rejects.toThrow(
+        `maxStackSize must be an integer between 0 and ${MAX_STACK_SIZE}`,
+      );
+    },
+  );
 });
 
 describe('interruptHandler', () => {


### PR DESCRIPTION
## What

Adds `maxStackSize` support to `quickjs-wasi`.

- Exposes `maxStackSize` through `QuickJS.create()` and `QuickJS.restore()`
- Adds a safe 512 KiB maximum for the shipped 1 MiB WASM stack
- Makes recursive stack overflows catchable inside guest JavaScript

## Why

The `run` SDK passes a stack limit to QuickJS, but `quickjs-wasi` did not apply it. Deep recursion could therefore exhaust the physical WASM stack and crash with a WebAssembly trap instead of throwing a catchable JavaScript error.

This closes the gap found while integrating `quickjs-wasi` into `run`:

- https://github.com/vercel-labs/run/pull/42
- https://github.com/vercel-labs/run/pull/43

## NOTE

the currently failing CI test is expected until we land the fix in https://github.com/quickjs-ng/quickjs/pull/1700 and update the submodule SHA here

## Future Work

- [x] The quickjs-ng submodule in this repo will need to be updated to include the patch fix https://github.com/quickjs-ng/quickjs/pull/1700, once it's merged
- [x] update https://github.com/vercel-labs/run/pull/43 to use the patched version after this fix